### PR TITLE
Allow exclusion of http requests from tracing

### DIFF
--- a/src/main/docs/guide/jaeger.adoc
+++ b/src/main/docs/guide/jaeger.adoc
@@ -73,3 +73,19 @@ tracing:
 ----
 
 You can also optionally dependency-inject common configuration classes into api:tracing.jaeger.JaegerConfiguration[] such as `io.jaegertracing.Configuration.SamplerConfiguration` just by defining them as beans. See the API for api:tracing.jaeger.JaegerConfiguration[] for available injection points.
+
+== Filtering http spans
+
+It may be useful to exclude health-checks and other http requests to your service.
+This can be achieved by adding a list of regular expression patterns to your configuration:
+
+.Filtering http request spans
+[source,yaml]
+----
+tracing:
+  jaeger:
+    enabled: true
+  exclusions:
+    - /health
+    - /env/.*
+----

--- a/src/main/docs/guide/zipkin.adoc
+++ b/src/main/docs/guide/zipkin.adoc
@@ -87,3 +87,19 @@ tracing:
 ----
 
 You can also optionally dependency-inject common configuration classes into api:tracing.brave.BraveTracerConfiguration[] such as `brave.sampler.Sampler` just by defining them as beans. See the API for api:tracing.brave.BraveTracerConfiguration[] for available injection points.
+
+== Filtering http spans
+
+It may be useful to exclude health-checks and other http requests to your service.
+This can be achieved by adding a list of regular expression patterns to your configuration:
+
+.Filtering http request spans
+[source,yaml]
+----
+tracing:
+  zipkin:
+    enabled: true
+  exclusions:
+    - /health
+    - /env/.*
+----

--- a/tracing-core/src/main/java/io/micronaut/tracing/instrument/http/TracingExclusionsConfiguration.java
+++ b/tracing-core/src/main/java/io/micronaut/tracing/instrument/http/TracingExclusionsConfiguration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.instrument.http;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.CollectionUtils;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @since 3.3.0
+ */
+@ConfigurationProperties(TracingExclusionsConfiguration.PREFIX)
+public class TracingExclusionsConfiguration {
+
+    public static final String PREFIX = "tracing";
+    private List<String> exclusions;
+
+    /**
+     * @return The URI patterns to exclude from the tracing.
+     */
+    @Nullable public List<String> getExclusions() {
+        return exclusions;
+    }
+
+    /**
+     * Sets the URI patterns to be excluded from tracing.
+     *
+     * @param exclusions A list of regular expression patterns to be excluded from tracing if the request URI matches.
+     *
+     * @see Pattern#compile(String)
+     */
+    public void setExclusions(@Nullable List<String> exclusions) {
+        this.exclusions = exclusions;
+    }
+
+    /**
+     * @return Either null (implying everything should be included), or a Predicate which when given a URL path returns
+     *         whether that path should be excluded from tracing.
+     */
+    @Nullable public Predicate<String> exclusionTest() {
+        if (CollectionUtils.isEmpty(exclusions)) {
+            return null;
+        } else {
+            List<Pattern> patterns = exclusions.stream().map(Pattern::compile).collect(Collectors.toList());
+            return uri -> patterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        }
+    }
+}

--- a/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/http/TracingExclusionsConfigurationSpec.groovy
+++ b/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/http/TracingExclusionsConfigurationSpec.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.tracing.instrument.http
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.function.Predicate
+
+class TracingExclusionsConfigurationSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
+            'tracing.exclusions[0]': '.*pattern.*',
+            'tracing.exclusions[1]': '/literal',
+    )
+
+    TracingExclusionsConfiguration configuration = context.getBean(TracingExclusionsConfiguration)
+
+    Predicate<String> pathPredicate = configuration.exclusionTest()
+
+    @Unroll
+    def "path #path is #desc by predicate"() {
+        expect:
+        pathPredicate.test(path) == excluded
+
+        where:
+        path            | excluded
+        '/some/pattern' | true
+        '/patterns'     | true
+        '/another'      | false
+        '/literal'      | true
+        '/literal/sub'  | false
+
+        desc = excluded ? 'excluded' : 'included'
+    }
+}


### PR DESCRIPTION
This change allows configuration of a list of regular-expression patterns for tracing.

If the current path matches one of these patterns, then tracing is not performed on that
request.

Follows the same config naming strategy as the exclusion of access logs entries in

https://github.com/micronaut-projects/micronaut-core/pull/6753