### PR TITLE
Fix 'Flow invariant is violated' with CoroutineTracingDispatcher

### DIFF
--- a/tracing-core/src/main/kotlin/io/micronaut/tracing/instrument/kotlin/CoroutineTracingDispatcher.kt
+++ b/tracing-core/src/main/kotlin/io/micronaut/tracing/instrument/kotlin/CoroutineTracingDispatcher.kt
@@ -20,14 +20,14 @@ import io.micronaut.scheduling.instrument.InvocationInstrumenter
 import kotlinx.coroutines.ThreadContextElement
 import kotlin.coroutines.CoroutineContext
 
-internal class CoroutineTracingDispatcherContextKey : CoroutineContext.Key<CoroutineTracingDispatcher>
+object CoroutineTracingDispatcherContextKey : CoroutineContext.Key<CoroutineTracingDispatcher>
 
 class CoroutineTracingDispatcher(
     private val invocationInstrumenters: List<InvocationInstrumenter>
 ): ThreadContextElement<List<Instrumentation>> {
 
     override val key: CoroutineContext.Key<*>
-        get() = CoroutineTracingDispatcherContextKey()
+        get() = CoroutineTracingDispatcherContextKey
 
     override fun restoreThreadContext(context: CoroutineContext, oldState: List<Instrumentation>) =
         oldState.forEach(Instrumentation::close)


### PR DESCRIPTION
Kotlin flow collection compares the collection and emission contexts by
looking up the context elements bey their keys. Therefore, the key of a
coroutine context element must be a fixed object.

See also https://github.com/micronaut-projects/micronaut-core/issues/6633 and https://github.com/bene1618/micronaut-flow-tracing-dispatcher-demo/blob/main/src/test/kotlin/com/example/FlowTracingDispatcherTest.kt