### PR TITLE
Add spanId and traceId to MDC when using Jaeger

### DIFF
--- a/src/main/docs/guide/jaeger.adoc
+++ b/src/main/docs/guide/jaeger.adoc
@@ -72,7 +72,7 @@ tracing:
     codecs: W3C,B3,JAEGER
 ----
 
-You can also optionally dependency-inject common configuration classes into api:tracing.jaeger.JaegerConfiguration[] such as `io.jaegertracing.Configuration.SamplerConfiguration` just by defining them as beans. See the API for api:tracing.jaeger.JaegerConfiguration[] for available injection points.
+You can also optionally dependency-inject common configuration classes into api:tracing.jaeger.JaegerConfiguration[] such as `io.jaegertracing.Configuration.SamplerConfiguration` just by defining them as beans. Likewise, a custom `io.opentracing.ScopeManager` can be injected into api:tracing.jaeger.JaegerTracerFactory[]. See the API for api:tracing.jaeger.JaegerConfiguration[] and api:tracing.jaeger.JaegerTracerFactory[] for available injection points.
 
 == Filtering HTTP spans
 

--- a/tracing-jaeger/src/main/java/io/micronaut/tracing/jaeger/JaegerTracerFactory.java
+++ b/tracing-jaeger/src/main/java/io/micronaut/tracing/jaeger/JaegerTracerFactory.java
@@ -17,12 +17,14 @@ package io.micronaut.tracing.jaeger;
 
 import io.jaegertracing.Configuration;
 import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.MDCScopeManager;
 import io.jaegertracing.spi.Reporter;
 import io.jaegertracing.spi.Sampler;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;
+import io.opentracing.ScopeManager;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 import jakarta.annotation.PreDestroy;
@@ -46,6 +48,7 @@ public class JaegerTracerFactory implements Closeable {
     private final JaegerConfiguration configuration;
     private Reporter reporter;
     private Sampler sampler;
+    private ScopeManager scopeManager = new MDCScopeManager.Builder().build();
 
     /**
      * @param configuration the configuration
@@ -72,6 +75,18 @@ public class JaegerTracerFactory implements Closeable {
     @Inject
     public void setSampler(@Nullable Sampler sampler) {
         this.sampler = sampler;
+    }
+
+    /**
+     * Overrides the default MDCScopeManager with a custom scope manager.
+     *
+     * @param scopeManager the scope manager
+     */
+    @Inject
+    public void setScopeManager(@Nullable ScopeManager scopeManager) {
+        if (scopeManager != null) {
+            this.scopeManager = scopeManager;
+        }
     }
 
     /**
@@ -109,6 +124,7 @@ public class JaegerTracerFactory implements Closeable {
         if (sampler != null) {
             tracerBuilder.withSampler(sampler);
         }
+        tracerBuilder.withScopeManager(scopeManager);
         return tracerBuilder;
     }
 


### PR DESCRIPTION
Currently the MDC is filled with traceId and spanId only when using the zipkin tracer from micronaut. I set up a [small project](https://github.com/gobbi9/mn-mdc-trace) where it is possible to see the difference.

The jaeger dependency already includes a mechanism to do this, see <https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-core#log-correlation>. All I did was to include this call in the factory class.

The MDCScopeManager is used by default and can be overridden with bean injection. Since [with zipkin](https://github.com/micronaut-projects/micronaut-tracing/blob/master/tracing-zipkin/src/main/java/io/micronaut/tracing/brave/log/Slf4jScopeDecorator.java) the MDC is filled by default with the traceId, the jaeger implementation should do the same for consistency.

Might be related to https://github.com/micronaut-projects/micronaut-core/issues/5222