### PR TITLE
Fix #30 remove kotlin-stdlib dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ githubCoreBranch=3.3.x
 bomProperty=micronautTracingVersion
 
 org.gradle.caching=true
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Added `kotlin.stdlib.default.dependency=false` inside `gradle.properties` file. Module now should not depend on  `kotlin-stdlib` dependency.

References:
https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library