### PR TITLE
TracingCorePublisher should be able to handle any type of Subscriber

### DIFF
--- a/tracing-core/build.gradle
+++ b/tracing-core/build.gradle
@@ -13,4 +13,6 @@ dependencies {
     compileOnly libs.kotlinx.coroutines.reactor
 
     testImplementation mn.reactor
+    testImplementation mn.rxjava2
+    testImplementation mn.micronaut.rxjava2.http.client
 }

--- a/tracing-core/build.gradle
+++ b/tracing-core/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     testImplementation mn.reactor
     testImplementation mn.rxjava2
     testImplementation mn.micronaut.rxjava2.http.client
+    testImplementation mn.micronaut.reactor.http.client
 }

--- a/tracing-core/src/main/java/io/micronaut/tracing/instrument/util/TracingCorePublisher.java
+++ b/tracing-core/src/main/java/io/micronaut/tracing/instrument/util/TracingCorePublisher.java
@@ -22,6 +22,7 @@ import io.opentracing.Tracer.SpanBuilder;
 import org.reactivestreams.Subscriber;
 import reactor.core.CorePublisher;
 import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
 import reactor.util.context.Context;
 
 /**
@@ -159,12 +160,8 @@ public class TracingCorePublisher<T> extends TracingPublisher<T> implements Core
                                ScopeManager scopeManager,
                                Span span,
                                boolean finishOnClose) {
-        if (actual instanceof  CoreSubscriber) {
-            CoreSubscriber<? extends T> coreActual = (CoreSubscriber<? extends T>) actual;
-            publisher.subscribe(new TracingCoreSubscriber(scopeManager, span, actual, finishOnClose, coreActual.currentContext()));
-        } else {
-            publisher.subscribe(new TracingSubscriber(scopeManager, span, actual, finishOnClose));
-        }
+        CoreSubscriber<? super T> coreActual = Operators.toCoreSubscriber(actual);
+        publisher.subscribe(new TracingCoreSubscriber(scopeManager, span, actual, finishOnClose, coreActual.currentContext()));
     }
 
     private final class TracingCoreSubscriber extends TracingSubscriber implements CoreSubscriber<T> {

--- a/tracing-core/src/main/java/io/micronaut/tracing/instrument/util/TracingCorePublisher.java
+++ b/tracing-core/src/main/java/io/micronaut/tracing/instrument/util/TracingCorePublisher.java
@@ -159,8 +159,12 @@ public class TracingCorePublisher<T> extends TracingPublisher<T> implements Core
                                ScopeManager scopeManager,
                                Span span,
                                boolean finishOnClose) {
-        CoreSubscriber<? extends T> coreActual = (CoreSubscriber<? extends T>) actual;
-        publisher.subscribe(new TracingCoreSubscriber(scopeManager, span, actual, finishOnClose, coreActual.currentContext()));
+        if (actual instanceof  CoreSubscriber) {
+            CoreSubscriber<? extends T> coreActual = (CoreSubscriber<? extends T>) actual;
+            publisher.subscribe(new TracingCoreSubscriber(scopeManager, span, actual, finishOnClose, coreActual.currentContext()));
+        } else {
+            publisher.subscribe(new TracingSubscriber(scopeManager, span, actual, finishOnClose));
+        }
     }
 
     private final class TracingCoreSubscriber extends TracingSubscriber implements CoreSubscriber<T> {

--- a/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/util/MDCReactorSpec.groovy
+++ b/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/util/MDCReactorSpec.groovy
@@ -22,7 +22,9 @@ import io.micronaut.http.filter.HttpClientFilter
 import io.micronaut.http.filter.HttpServerFilter
 import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.rxjava2.http.client.RxHttpClient
 import io.micronaut.scheduling.annotation.ExecuteOn
+import io.reactivex.Single
 import jakarta.inject.Inject
 import org.reactivestreams.Publisher
 import org.slf4j.Logger
@@ -86,6 +88,10 @@ class MDCReactorSpec extends Specification {
         private HttpClient httpClient
 
         @Inject
+        @Client("/")
+        private RxHttpClient rxHttpClient
+
+        @Inject
         @Client
         private MDCClient mdcClient
 
@@ -111,12 +117,11 @@ class MDCReactorSpec extends Specification {
         }
 
         @Put("/test3")
-        Mono<String> test3(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
+        Single<String> test3(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
             LOG.info("test3")
             checkTracing(tracingId)
-
-            return Mono.from(
-                    httpClient.retrieve(HttpRequest
+            return Single.fromPublisher(
+                    rxHttpClient.retrieve(HttpRequest
                             .POST("/mdc/test4", body)
                             .header("X-TrackingId", tracingId), String)
             )

--- a/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/util/MDCReactorSpec.groovy
+++ b/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/util/MDCReactorSpec.groovy
@@ -22,9 +22,7 @@ import io.micronaut.http.filter.HttpClientFilter
 import io.micronaut.http.filter.HttpServerFilter
 import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.rxjava2.http.client.RxHttpClient
 import io.micronaut.scheduling.annotation.ExecuteOn
-import io.reactivex.Single
 import jakarta.inject.Inject
 import org.reactivestreams.Publisher
 import org.slf4j.Logger
@@ -88,10 +86,6 @@ class MDCReactorSpec extends Specification {
         private HttpClient httpClient
 
         @Inject
-        @Client("/")
-        private RxHttpClient rxHttpClient
-
-        @Inject
         @Client
         private MDCClient mdcClient
 
@@ -117,11 +111,12 @@ class MDCReactorSpec extends Specification {
         }
 
         @Put("/test3")
-        Single<String> test3(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
+        Mono<String> test3(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
             LOG.info("test3")
             checkTracing(tracingId)
-            return Single.fromPublisher(
-                    rxHttpClient.retrieve(HttpRequest
+
+            return Mono.from(
+                    httpClient.retrieve(HttpRequest
                             .POST("/mdc/test4", body)
                             .header("X-TrackingId", tracingId), String)
             )

--- a/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/util/ReactorRx2JavaSpec.groovy
+++ b/tracing-core/src/test/groovy/io/micronaut/tracing/instrument/util/ReactorRx2JavaSpec.groovy
@@ -1,0 +1,119 @@
+package io.micronaut.tracing.instrument.util
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.reactor.http.client.ReactorHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.rxjava2.http.client.RxHttpClient
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.tracing.annotation.ContinueSpan
+import io.micronaut.tracing.annotation.NewSpan
+import io.reactivex.Flowable
+import io.reactivex.Single
+import jakarta.inject.Inject
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.util.function.Tuple2
+import reactor.util.function.Tuples
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+import static io.micronaut.scheduling.TaskExecutors.IO
+
+class ReactorRx2JavaSpec extends Specification {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReactorRx2JavaSpec)
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+
+    @Shared
+    @AutoCleanup
+    RxHttpClient rxHttpClient = RxHttpClient.create(embeddedServer.URL)
+
+    void "test RxJava2 integration"() {
+        expect:
+        List<Tuple2> result = Flux.range(1, 1)
+                .flatMap {
+                    String tracingId = UUID.randomUUID()
+                    HttpRequest<Object> request = HttpRequest
+                            .POST("/rxjava2/enter", new SomeBody())
+                            .header("X-TrackingId", tracingId)
+                    return Mono.from(rxHttpClient.retrieve(request)).map(response -> {
+                        Tuples.of(tracingId, response)
+                    })
+                }
+                .collectList()
+                .block()
+        for (Tuple2 t : result)
+            assert t.getT1() == t.getT2()
+    }
+
+    @Introspected
+    static class SomeBody {
+    }
+
+    @Controller("/rxjava2")
+    static class RxJava2Controller {
+
+        @Inject
+        @Client("/")
+        private RxHttpClient rxHttpClient
+
+        @Inject
+        @Client("/")
+        private ReactorHttpClient reactorHttpClient
+
+        @ExecuteOn(IO)
+        @ContinueSpan
+        @Post("/enter")
+        Single<String> test(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
+            LOG.info("enter")
+            return Single.fromPublisher(
+                    reactorHttpClient.retrieve(HttpRequest
+                            .GET("/rxjava2/test")
+                            .header("X-TrackingId", tracingId), String)
+            )
+        }
+
+        @ExecuteOn(IO)
+        @Get("/test")
+        @ContinueSpan
+        Mono<String> testRxJava2(@Header("X-TrackingId") String tracingId) {
+            LOG.info("test")
+            return Mono.from(
+                    rxHttpClient.exchange(HttpRequest
+                            .GET("/rxjava2/test2")
+                            .header("X-TrackingId", tracingId), String)
+            )
+        }
+
+        @ExecuteOn(IO)
+        @Get("/test2")
+        @ContinueSpan
+        String test2RxJava2(@Header("X-TrackingId") String tracingId) {
+            LOG.info("test2")
+            return Flux.from(trackingIdRxJava2(tracingId)).blockFirst()
+        }
+
+
+        @NewSpan("test")
+        Flowable<String> trackingIdRxJava2(String tracingId) {
+           return Flowable.just(tracingId, tracingId, tracingId)
+        }
+
+    }
+
+}


### PR DESCRIPTION
`TracingCorePublisher` can handle any type of Subscriber. Changed from casting to converting the `Subscriber` to `CoreSubscriber` with `Operators.toCoreSubscriber`

Fix #41