### PR TITLE
Fix #8 add native image configuration for open-telemetry

### DIFF
--- a/tracing-opentelemetry/src/main/resources/META-INF/native-image/io.micronaut.tracing/micronaut-tracing-opentelemetry/reflect-config.json
+++ b/tracing-opentelemetry/src/main/resources/META-INF/native-image/io.micronaut.tracing/micronaut-tracing-opentelemetry/reflect-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name":"io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter"
+  },
+  {
+    "name":"io.opentelemetry.exporter.zipkin.ZipkinSpanExporter"
+  },
+  {
+    "name":"io.opentelemetry.exporter.logging.LoggingSpanExporter"
+  },
+  {
+    "name":"io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter"
+  },
+  {
+    "name":"io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueConsumerIndexField",
+    "fields":[{"name":"consumerIndex"}]
+  },
+  {
+    "name":"io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerIndexField",
+    "fields":[{"name":"producerIndex"}]
+  },
+  {
+    "name":"io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerLimitField",
+    "fields":[{"name":"producerLimit"}]
+  },
+  {
+    "name":"io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+    "methods":[{"name":"setExemplarFilter","parameterTypes":["io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter"] }]
+  }
+]


### PR DESCRIPTION
This PR adds native-image configuration. The native-image compiler will now consider exporter dependencies:

```
    implementation("io.opentelemetry:opentelemetry-exporter-jaeger")
    implementation("io.opentelemetry:opentelemetry-exporter-zipkin")
    implementation("io.opentelemetry:opentelemetry-exporter-logging")
    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
```

