### PR TITLE
Fixes #29. Adds Tracing Subscribers inside zipkin and opentelemetry

### DIFF
--- a/tracing-opentelemetry/src/main/resources/META-INF/native-image/io.micronaut.tracing/micronaut-tracing-opentelemetry/native-image.properties
+++ b/tracing-opentelemetry/src/main/resources/META-INF/native-image/io.micronaut.tracing/micronaut-tracing-opentelemetry/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:+AddAllCharsets

--- a/tracing-zipkin/src/main/java/io/micronaut/tracing/brave/instrument/http/BraveTracingClientFilter.java
+++ b/tracing-zipkin/src/main/java/io/micronaut/tracing/brave/instrument/http/BraveTracingClientFilter.java
@@ -31,6 +31,7 @@ import io.micronaut.tracing.instrument.http.OpenTracingClientFilter;
 import io.micronaut.tracing.instrument.http.TracingExclusionsConfiguration;
 import jakarta.inject.Inject;
 import org.reactivestreams.Publisher;
+import reactor.core.CorePublisher;
 
 import java.util.function.Predicate;
 
@@ -84,6 +85,11 @@ public class BraveTracingClientFilter implements HttpClientFilter {
         if (shouldExclude(request.getPath())) {
             return requestPublisher;
         }
+
+        if (requestPublisher instanceof CorePublisher) {
+            return new HttpClientTracingCorePublisher(requestPublisher, request, clientHandler, httpTracing);
+        }
+
         return new HttpClientTracingPublisher(requestPublisher, request, clientHandler, httpTracing);
     }
 

--- a/tracing-zipkin/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpClientTracingCorePublisher.java
+++ b/tracing-zipkin/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpClientTracingCorePublisher.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.brave.instrument.http;
+
+import brave.Span;
+import brave.http.HttpClientHandler;
+import brave.http.HttpClientRequest;
+import brave.http.HttpClientResponse;
+import brave.http.HttpTracing;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.CorePublisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+/**
+ * Handles HTTP client request tracing.
+ *
+ * @author Nemanja Mikic
+ * @since 4.1.0
+ */
+@SuppressWarnings("PublisherImplementation")
+class HttpClientTracingCorePublisher extends HttpClientTracingPublisher implements CorePublisher<HttpResponse<?>> {
+
+    /**
+     * @param publisher     the response publisher
+     * @param request       an extended version of request that allows mutating
+     * @param clientHandler the standardize way to instrument client
+     * @param httpTracing   <code>HttpTracing</code>
+     */
+    HttpClientTracingCorePublisher(Publisher<? extends HttpResponse<?>> publisher, MutableHttpRequest<?> request, HttpClientHandler<HttpClientRequest, HttpClientResponse> clientHandler, HttpTracing httpTracing) {
+        super(publisher, request, clientHandler, httpTracing);
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super HttpResponse<?>> subscriber) {
+        subscribe((Subscriber) subscriber);
+    }
+
+    @Override
+    protected void doSubscribe(Subscriber<? super HttpResponse<?>>  actual, Span span) {
+        CoreSubscriber<? super HttpResponse<?>> coreActual = Operators.toCoreSubscriber(actual);
+        publisher.subscribe(new TracingCoreSubscriber(actual, span,  coreActual.currentContext()));
+    }
+
+    private final class TracingCoreSubscriber extends TracingHttpClientSubscriber implements CoreSubscriber<HttpResponse<?>> {
+
+        private final Context context;
+
+        public TracingCoreSubscriber(Subscriber<? super HttpResponse<?>> actual,
+                                     Span span,
+                                     Context context) {
+            super(actual, span);
+            this.context = context;
+        }
+
+        @Override
+        public Context currentContext() {
+            return context;
+        }
+    }
+
+
+}

--- a/tracing-zipkin/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpServerTracingCorePublisher.java
+++ b/tracing-zipkin/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpServerTracingCorePublisher.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.brave.instrument.http;
+
+import brave.Span;
+import brave.http.HttpServerHandler;
+import brave.http.HttpServerRequest;
+import brave.http.HttpServerResponse;
+import brave.http.HttpTracing;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.CorePublisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+/**
+ * Handles HTTP client server tracing.
+ *
+ * @author Nemanja Mikic
+ * @since 4.1.0
+ */
+public class HttpServerTracingCorePublisher extends HttpServerTracingPublisher implements CorePublisher<MutableHttpResponse<?>> {
+
+    /**
+     * Construct a publisher to handle HTTP client request tracing.
+     *
+     * @param publisher     the response publisher
+     * @param request       an extended version of request that allows mutating
+     * @param serverHandler the standard way to instrument client
+     * @param httpTracing   <code>HttpTracing</code>
+     * @param openTracer    the Open Tracing instance
+     * @param initialSpan   the initial span
+     */
+    HttpServerTracingCorePublisher(Publisher<MutableHttpResponse<?>> publisher, HttpRequest<?> request, HttpServerHandler<HttpServerRequest, HttpServerResponse> serverHandler, HttpTracing httpTracing, io.opentracing.Tracer openTracer, Span initialSpan) {
+        super(publisher, request, serverHandler, httpTracing, openTracer, initialSpan);
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super MutableHttpResponse<?>> subscriber) {
+        subscribe((Subscriber) subscriber);
+    }
+
+    @Override
+    protected void doSubscribe(Span span, Subscriber<? super MutableHttpResponse<?>> actual) {
+        CoreSubscriber<? super MutableHttpResponse<?>> coreActual = Operators.toCoreSubscriber(actual);
+        publisher.subscribe(new TracingCoreSubscriber(actual, span,  coreActual.currentContext()));
+    }
+
+    private final class TracingCoreSubscriber extends TracingSubscriber implements CoreSubscriber<MutableHttpResponse<?>> {
+
+        private final Context context;
+
+        public TracingCoreSubscriber(Subscriber<? super MutableHttpResponse<?>> actual,
+                                     Span span,
+                                     Context context) {
+            super(span, actual);
+            this.context = context;
+        }
+
+        @Override
+        public Context currentContext() {
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
Adds CorePublishers and TracingSubscribers inside:

- tracing-opentelemetry module
- tracing-zipkin module.

Context now will be correctly propagated. 
Fixes issue with OkHttp when generating the native Image with `implementation("io.opentelemetry:opentelemetry-exporter-zipkin")`