### PR TITLE
Add customisation of the IdGenerator

### DIFF
--- a/src/main/docs/guide/opentelemetry.adoc
+++ b/src/main/docs/guide/opentelemetry.adoc
@@ -55,3 +55,26 @@ otel:
     exporter: otlp
   propagators: tracecontext, baggage, xray
 ----
+
+== ID Generator
+Some custom vendor may require the span traceId in different format from the default one. You can specify an https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/IdGenerator.java[ID Generator] by creating it in some factory. For an example AWS X-Ray requires their format for generating ids.
+
+[source,java]
+----
+
+@Factory
+public class AwsFactory {
+
+    /** Creates a custom IdGenerator for OpenTelemetry */
+    @Singleton
+    IdGenerator idGenerator() {
+        return AwsXrayIdGenerator.getInstance();
+    }
+}
+----
+
+The https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayIdGenerator.java[AwsXrayIdGenerator] is available by adding the next dependency inside your project:
+
+dependency:opentelemetry-aws-xray[scope="implementation", groupId="io.opentelemetry.contrib", version="1.14.0"]
+
+To successfully export traces to the AWS X-Ray you have to run https://github.com/aws-observability/aws-otel-collector[AWS Open Telemetry Collector] that will periodically send traces to the AWS.

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -53,8 +53,11 @@ class OpenTelemetryHttpSpec extends Specification {
     ReactorHttpClient reactorHttpClient
 
     private PollingConditions conditions = new PollingConditions()
+
+    @AutoCleanup
     private EmbeddedServer embeddedServer
-    private InMemorySpanExporter exporter;
+
+    private InMemorySpanExporter exporter
 
     void setup() {
         context = ApplicationContext.builder(
@@ -62,6 +65,7 @@ class OpenTelemetryHttpSpec extends Specification {
             'otel.http.client.response-headers': [TRACING_ID],
             'otel.http.server.request-headers': [TRACING_ID],
             'otel.http.server.response-headers': [TRACING_ID],
+            'otel.register.global':false,
             'micronaut.application.name': 'test-app',
             'otel.exclusions[0]': '.*exclude.*'
         ).start()

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/util/TestDefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/util/TestDefaultOpenTelemetryFactory.java
@@ -16,35 +16,17 @@
 package io.micronaut.tracing.instrument.util;
 
 import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Primary;
-import io.micronaut.context.annotation.Replaces;
-import io.micronaut.tracing.DefaultOpenTelemetryFactory;
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import jakarta.inject.Singleton;
 
-/**
- * Registers an OpenTelemetry bean for test.
- *
- */
 @Factory
-@Replaces(factory = DefaultOpenTelemetryFactory.class)
 public class TestDefaultOpenTelemetryFactory {
 
-    /**
-     * @return the OpenTelemetry bean with default values
-     */
     @Singleton
-    @Primary
-    OpenTelemetry defaultOpenTelemetry(InMemorySpanExporter inMemorySpanExporter) {
-        return OpenTelemetrySdk.builder()
-            .setTracerProvider(SdkTracerProvider.builder()
-                .addSpanProcessor(SimpleSpanProcessor.create(inMemorySpanExporter))
-                .build()
-            ).build();
+    SpanProcessor spanProcessor(InMemorySpanExporter spanExporter) {
+        return SimpleSpanProcessor.create(spanExporter);
     }
 
     @Singleton

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/TestDefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/TestDefaultOpenTelemetryFactory.java
@@ -16,37 +16,23 @@
 package io.micronaut.tracing.instrument.util;
 
 import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Primary;
-import io.micronaut.context.annotation.Replaces;
-import io.micronaut.tracing.DefaultOpenTelemetryFactory;
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import jakarta.inject.Singleton;
 
-/**
- * Registers an OpenTelemetry bean.
- *
- * @author Nemanja Mikic
- * @since 4.1.0
- */
 @Factory
-@Replaces(factory = DefaultOpenTelemetryFactory.class)
 public class TestDefaultOpenTelemetryFactory {
 
-    /**
-     * @return the OpenTelemetry bean with default values
-     */
     @Singleton
-    @Primary
-    OpenTelemetry defaultOpenTelemetry(InMemorySpanExporter spanExporter) {
-        return OpenTelemetrySdk.builder()
-            .setTracerProvider(SdkTracerProvider.builder()
-                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
-                .build()
-            ).build();
+    SpanProcessor spanProcessor(InMemorySpanExporter spanExporter) {
+        return SimpleSpanProcessor.create(spanExporter);
+    }
+
+    @Singleton
+    IdGenerator idGenerator() {
+        return IdGenerator.random();
     }
 
     @Singleton


### PR DESCRIPTION
The AWS X-Ray requires traceIds in different format from the default one.

This PR adds possibility to configure custom IdGenerator. Here is an example:

```
@Factory
public class AwsFactory {

    @Singleton
    IdGenerator idGenerator() {
        return AwsXrayIdGenerator.getInstance();
    }
}
```