### PR TITLE
refactor: remove @Primary for OpenTelemetry factory method

### DIFF
--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -16,7 +16,6 @@
 package io.micronaut.tracing.opentelemetry;
 
 import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.MapFormat;
@@ -59,7 +58,6 @@ public class DefaultOpenTelemetryFactory {
      * @return the OpenTelemetry bean with default values
      */
     @Singleton
-    @Primary
     protected OpenTelemetry defaultOpenTelemetry(ApplicationConfiguration applicationConfiguration,
                                                  @Property(name = "otel") @MapFormat(transformation = FLAT) Map<String, String> otelConfig,
                                                  @Nullable IdGenerator idGenerator,


### PR DESCRIPTION
Not sure why this is annotated with `@Primary`? Is it necessary?