### PR TITLE
Fix #114 peerName of client will use id if doesn't contain path

### DIFF
--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -54,10 +54,14 @@ class OpenTelemetryHttpSpec extends Specification {
     @AutoCleanup
     private EmbeddedServer embeddedServer
 
+    @AutoCleanup
+    private EmbeddedServer dummy = ApplicationContext.builder().start().getBean(EmbeddedServer).start()
+
     private InMemorySpanExporter exporter
 
     void setup() {
         context = ApplicationContext.builder(
+            'micronaut.http.services.correctspanname.url': "http://localhost:${dummy.port}",
             'otel.http.client.request-headers': [TRACING_ID],
             'otel.http.client.response-headers': [TRACING_ID],
             'otel.http.server.request-headers': [TRACING_ID],
@@ -204,6 +208,25 @@ class OpenTelemetryHttpSpec extends Specification {
             testExporter.finishedSpanItems.name.contains("WarehouseClient.order")
             testExporter.finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("warehouse.order")) == "{testOrderKey=testOrderValue}")
             testExporter.finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("upc")) == "10")
+        }
+
+        cleanup:
+        testExporter.reset()
+    }
+
+    void 'client with tracing annotations that contains id inside annotation'() {
+        def testExporter = embeddedServer.applicationContext.getBean(InMemorySpanExporter)
+        def warehouseClient = embeddedServer.applicationContext.getBean(WarehouseClientWithId)
+        def serverSpanCount = 1
+        def clientSpanCount = 1
+
+        expect:
+
+        warehouseClient.order(Map.of("testOrderKey", "testOrderValue"))
+        conditions.eventually {
+            testExporter.finishedSpanItems.size() == serverSpanCount + clientSpanCount
+            testExporter.finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("warehouse.order")) == "{testOrderKey=testOrderValue}")
+            testExporter.finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("net.peer.name")) == "correctspanname")
         }
 
         cleanup:
@@ -396,6 +419,15 @@ class OpenTelemetryHttpSpec extends Specification {
         @Get("/count")
         @ContinueSpan
         int getItemCount(@QueryValue String store, @SpanTag @QueryValue int upc);
+
+        @Post("/order")
+        @NewSpan
+        void order(@SpanTag("warehouse.order") Map<String, ?> json);
+
+    }
+
+    @Client(id = "correctspanname")
+    static interface WarehouseClientWithId {
 
         @Post("/order")
         @NewSpan

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/interceptor/package-info.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/interceptor/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Method Interceptors for {@link o.micronaut.tracing.annotation.NewSpan} and {@link o.micronaut.tracing.annotation.ContinueSpan} annotations.
+ * Method Interceptors for {@link io.micronaut.tracing.annotation.NewSpan} and {@link io.micronaut.tracing.annotation.ContinueSpan} annotations.
  *
  * @author Nemanja Mikic
  * @since 4.1.0


### PR DESCRIPTION
This PR fixes issue with AWS X-Ray tracing.

OTLP collector for client span name is using the peerName from the `NetClientAttributesGetter`. With this change if there is id in `@Client` annotation it will be used as a `peerName`. if id contain '\' it means that it is using path and it will be ignored.  