### PR TITLE
refactor: return service_id if present

### DIFF
--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/MicronautHttpNetClientAttributesGetter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/MicronautHttpNetClientAttributesGetter.java
@@ -44,13 +44,8 @@ final class MicronautHttpNetClientAttributesGetter
     @Override
     public String peerName(MutableHttpRequest<Object> request,
                            @Nullable HttpResponse<Object> response) {
-
-        String serviceId = request.getAttribute(SERVICE_ID).orElse("/").toString();
-        if (!serviceId.contains("/")) {
-            return serviceId;
-        }
-
-        return getAddress(request).getHostString();
+        return request.getAttribute(SERVICE_ID, String.class)
+            .orElseGet(() -> getAddress(request).getHostString());
     }
 
     @Override


### PR DESCRIPTION
The code was checking wether the service Id contains a `/`. If it contained a `/` it was not returning the service id. Was it intentional? Could you explain me why? 