### PR TITLE
Fix issue with GlobalOpenTelemetry in tests

### DIFF
--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -108,5 +108,4 @@ public class DefaultOpenTelemetryFactory {
         }
     }
 
-
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -17,15 +17,18 @@ package io.micronaut.tracing.opentelemetry;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.ApplicationConfiguration;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SpanProcessor;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 
 import java.util.Map;
@@ -97,5 +100,13 @@ public class DefaultOpenTelemetryFactory {
         return sdk.build().getOpenTelemetrySdk();
 
     }
+
+    @PreDestroy
+    void resetForTest(Environment environment) {
+        if (environment.getActiveNames().contains(Environment.TEST)) {
+            GlobalOpenTelemetry.resetForTest();
+        }
+    }
+
 
 }

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/HttpClientResetForTestSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/HttpClientResetForTestSpec.groovy
@@ -33,13 +33,8 @@ class HttpClientResetForTestSpec extends Specification {
     @AutoCleanup
     ReactorHttpClient reactorHttpClient = ReactorHttpClient.create(embeddedServer.URL)
 
-    private PollingConditions conditions = new PollingConditions()
 
-    void 'test map WithSpan annotation'() {
-        int count = 1
-        // 2x Method call 1x NewSpan, 1x WithSpan  = 2
-        int spanNumbers = 2
-        def testExporter = embeddedServer.applicationContext.getBean(InMemorySpanExporter)
+    void 'test pre destroy resetForTest'() {
         String tracingId = UUID.randomUUID()
 
         expect:
@@ -48,9 +43,6 @@ class HttpClientResetForTestSpec extends Specification {
                 .header("X-TrackingId", tracingId)
         def resp = reactorHttpClient.toBlocking().retrieve(request)
         resp == tracingId
-
-        cleanup:
-        testExporter.reset()
     }
 
     @Controller("/test")

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/HttpClientResetForTestSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/HttpClientResetForTestSpec.groovy
@@ -2,10 +2,14 @@ package io.micronaut.tracing.instrument.util
 
 import groovy.util.logging.Slf4j
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.HttpClient
 import io.micronaut.reactor.http.client.ReactorHttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.scheduling.annotation.ExecuteOn
@@ -26,30 +30,36 @@ class HttpClientResetForTestSpec extends Specification {
     @Shared
     @AutoCleanup
     EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
-            'micronaut.application.name': 'test-app'
+            'micronaut.application.name': 'test-app',
+            'spec.name': 'HttpClientResetForTestSpec'
     ])
 
     @Shared
     @AutoCleanup
-    ReactorHttpClient reactorHttpClient = ReactorHttpClient.create(embeddedServer.URL)
-
+    HttpClient httpClient = HttpClient.create(embeddedServer.URL)
 
     void 'test pre destroy resetForTest'() {
+        given:
         String tracingId = UUID.randomUUID()
 
-        expect:
+        when:
         HttpRequest<Object> request = HttpRequest
                 .GET("/test/test")
+                .accept(MediaType.TEXT_PLAIN)
                 .header("X-TrackingId", tracingId)
-        def resp = reactorHttpClient.toBlocking().retrieve(request)
+        String resp = httpClient.toBlocking().retrieve(request)
+
+        then:
+        noExceptionThrown()
         resp == tracingId
     }
 
+    @Requires(property = "spec.name", value = "HttpClientResetForTestSpec")
     @Controller("/test")
     static class TestController {
 
-
         @ExecuteOn(IO)
+        @Produces(MediaType.TEXT_PLAIN)
         @Get("/test")
         @ContinueSpan
         Mono<String> test(@SpanAttribute("tracing-annotation-span-attribute")

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/HttpClientResetForTestSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/instrument/util/HttpClientResetForTestSpec.groovy
@@ -1,0 +1,69 @@
+package io.micronaut.tracing.instrument.util
+
+import groovy.util.logging.Slf4j
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.reactor.http.client.ReactorHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.tracing.annotation.ContinueSpan
+import io.opentelemetry.extension.annotations.SpanAttribute
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import reactor.core.publisher.Mono
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import static io.micronaut.scheduling.TaskExecutors.IO
+
+@Slf4j("LOG")
+class HttpClientResetForTestSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.application.name': 'test-app'
+    ])
+
+    @Shared
+    @AutoCleanup
+    ReactorHttpClient reactorHttpClient = ReactorHttpClient.create(embeddedServer.URL)
+
+    private PollingConditions conditions = new PollingConditions()
+
+    void 'test map WithSpan annotation'() {
+        int count = 1
+        // 2x Method call 1x NewSpan, 1x WithSpan  = 2
+        int spanNumbers = 2
+        def testExporter = embeddedServer.applicationContext.getBean(InMemorySpanExporter)
+        String tracingId = UUID.randomUUID()
+
+        expect:
+        HttpRequest<Object> request = HttpRequest
+                .GET("/test/test")
+                .header("X-TrackingId", tracingId)
+        def resp = reactorHttpClient.toBlocking().retrieve(request)
+        resp == tracingId
+
+        cleanup:
+        testExporter.reset()
+    }
+
+    @Controller("/test")
+    static class TestController {
+
+
+        @ExecuteOn(IO)
+        @Get("/test")
+        @ContinueSpan
+        Mono<String> test(@SpanAttribute("tracing-annotation-span-attribute")
+                          @Header("X-TrackingId") String tracingId) {
+            LOG.debug("test")
+            return Mono.just(tracingId)
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes issue with tests.

- Added `PreDestroy` to the `DefaultOpenTelemetryFactory.java`. It will reset global openTelemetry if environment is `Environment.TEST`

Fix #150 