### PR TITLE
Fix GRPC 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ kotlin-coroutines = '1.6.4'
 grpc = '1.50.0'
 protobuf = '3.21.7'
 micronaut-docs = '2.0.0'
+javax-annotation = '1.3.2'
 
 [libraries]
 managed-opentelemetry-contrib-aws-xray = { module = 'io.opentelemetry.contrib:opentelemetry-aws-xray', version.ref = 'managed-opentelemetry-contrib-aws-xray'}
@@ -28,6 +29,7 @@ brave-opentracing = { module = 'io.opentracing.brave:brave-opentracing', version
 grpc-protobuf = { module = 'io.grpc:grpc-protobuf', version.ref = 'grpc' }
 grpc-stub = { module = 'io.grpc:grpc-stub', version.ref = 'grpc' }
 jaeger = { module = 'io.jaegertracing:jaeger-thrift', version.ref = 'managed-jaeger' }
+javax-annotation = { module = 'javax.annotation:javax.annotation-api', version.ref = 'javax-annotation' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version = '' }
 kotlinx-coroutines-core = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = 'kotlin-coroutines' }
 kotlinx-coroutines-reactor = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor', version.ref = 'kotlin-coroutines' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,12 +14,12 @@ managed-opentracing = '0.33.0'
 managed-opentracing-grpc = '0.2.3'
 managed-brave-opentracing = '1.0.0'
 
+javax-annotation = '1.3.2'
 kotlin = '1.7.20'
 kotlin-coroutines = '1.6.4'
 grpc = '1.50.0'
 protobuf = '3.21.7'
 micronaut-docs = '2.0.0'
-javax-annotation = '1.3.2'
 
 [libraries]
 managed-opentelemetry-contrib-aws-xray = { module = 'io.opentelemetry.contrib:opentelemetry-aws-xray', version.ref = 'managed-opentelemetry-contrib-aws-xray'}

--- a/tracing-opentelemetry-grpc/build.gradle
+++ b/tracing-opentelemetry-grpc/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compileOnly libs.kotlinx.coroutines.reactor
 
     testImplementation mn.micronaut.grpc.server.runtime
+    testImplementation libs.javax.annotation
     testImplementation libs.opentelemetry.sdk
     testImplementation libs.opentelemetry.sdk.testing
     testImplementation libs.opentracing.grpc


### PR DESCRIPTION
This PR adds `javax.annotation:javax.annotation-api` as test depenency

Fixes #190 