### PR TITLE
Add @Around again to support @NewSpan and @ContinueSpan on interfaces

### DIFF
--- a/tracing-annotation/src/main/java/io/micronaut/tracing/annotation/ContinueSpan.java
+++ b/tracing-annotation/src/main/java/io/micronaut/tracing/annotation/ContinueSpan.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.tracing.annotation;
 
+import io.micronaut.aop.Around;
 import io.micronaut.aop.InterceptorBinding;
 
 import java.lang.annotation.Inherited;
@@ -36,6 +37,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Inherited
 @Target({METHOD, ANNOTATION_TYPE})
+@Around
 @InterceptorBinding
 public @interface ContinueSpan {
 }

--- a/tracing-annotation/src/main/java/io/micronaut/tracing/annotation/NewSpan.java
+++ b/tracing-annotation/src/main/java/io/micronaut/tracing/annotation/NewSpan.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.tracing.annotation;
 
+import io.micronaut.aop.Around;
 import io.micronaut.aop.InterceptorBinding;
 import io.micronaut.context.annotation.Type;
 
@@ -37,6 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Inherited
 @Target({METHOD, ANNOTATION_TYPE})
+@Around
 @Type(InterceptorBinding.class)
 @InterceptorBinding
 public @interface NewSpan {


### PR DESCRIPTION
In order to solve https://github.com/micronaut-projects/micronaut-tracing/issues/201 I have added the `@Around` again to the `@NewSpan` and `@ContinueSpan` annotations. These were removed as part of https://github.com/micronaut-projects/micronaut-tracing/pull/65, but break functionality when used on interfaces.