### PR TITLE
ci: update github workflows

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ['17']
         graalvm: ['latest', 'dev']
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     outputs:
-      hashes: ${{ steps.hash.outputs.hashes }} # Computed hashes for build artifacts.
+      artifacts-sha256: ${{ steps.hash.outputs.artifacts-sha256 }} # Computed hashes for build artifacts.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -21,8 +21,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
           java-version: '11'
+          distribution: 'temurin'
       - name: Set the current release version
         id: release_version
         run: echo ::set-output name=release_version::${GITHUB_REF:11}
@@ -52,8 +52,8 @@ jobs:
           VERSION=$(./gradlew properties | grep 'version:' | awk '{print $2}')
           # Read the project group from gradle.properties.
           GROUP_PATH=$(./gradlew properties| grep "projectGroup" | awk '{print $2}' | sed 's/\./\//g')
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=group::$GROUP_PATH"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "group=$GROUP_PATH" >> "$GITHUB_OUTPUT"
       - name: Generate subject
         id: hash
         run: |
@@ -61,13 +61,21 @@ jobs:
           ARTIFACTS=$(find  build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
               -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)')
           # Compute the hashes for the artifacts.
-          echo "::set-output name=hashes::$(sha256sum $ARTIFACTS | base64 -w0)"
+          # Set the hash as job output for debugging.
+          echo "artifacts-sha256=$(sha256sum $ARTIFACTS | base64 -w0)" >> "$GITHUB_OUTPUT"
+          # Store the hash in a file, which is uploaded as a workflow artifact.
+          echo $(sha256sum $ARTIFACTS | base64 -w0) > artifacts-sha256
       - name: Upload build artifacts
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: gradle-build-outputs
           path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
-          if-no-files-found: error
+          retention-days: 5
+      - name: Upload artifacts-sha256
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: artifacts-sha256
+          path: artifacts-sha256
           retention-days: 5
       - name: Generate docs
         env:
@@ -113,27 +121,47 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  provenance:
+  provenance-subject:
     needs: [release]
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts-sha256: ${{ steps.set-hash.outputs.artifacts-sha256 }}
+    steps:
+      - name: Download artifacts-sha256
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        with:
+          name: artifacts-sha256
+      # The SLSA provenance generator expects the hash digest of artifacts to be passed as a job
+      # output. So we need to download the artifacts-sha256 and set it as job output. The hash of
+      # the artifacts should be set as output directly in the release job. But due to a known bug
+      # in GitHub Actions we have to use a workaround.
+      # See https://github.com/community/community/discussions/37942.
+      - name: Set artifacts-sha256 as output
+        id: set-hash
+        shell: bash
+        run: echo "artifacts-sha256=$(cat artifacts-sha256)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [release, provenance-subject]
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
     with:
-      base64-subjects: "${{ needs.release.outputs.hashes }}"
+      base64-subjects: "${{ needs.provenance-subject.outputs.artifacts-sha256 }}"
       upload-assets: true # Upload to a new release.
       compile-generator: true # Build the generator from source.
 
   github_release:
-    needs: [release, provenance]
+    needs: [release]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       - name: Download artifacts
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
         with:
           name: gradle-build-outputs
           path: build/repo


### PR DESCRIPTION
[4.5.0 release failed](https://github.com/micronaut-projects/micronaut-tracing/actions/runs/3426859052)

This aligns workflows with the [project template](https://github.com/micronaut-projects/micronaut-project-template)