### PR TITLE
Fix NPE in Kotlin tests

### DIFF
--- a/tracing-core/src/main/java/io/micronaut/tracing/instrument/kotlin/HttpCoroutineTracingDispatcherFactory.java
+++ b/tracing-core/src/main/java/io/micronaut/tracing/instrument/kotlin/HttpCoroutineTracingDispatcherFactory.java
@@ -26,6 +26,7 @@ import kotlin.coroutines.CoroutineContext;
 import kotlinx.coroutines.ThreadContextElement;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -50,7 +51,8 @@ final class HttpCoroutineTracingDispatcherFactory implements HttpCoroutineContex
     @Override
     public CoroutineTracingDispatcher create() {
         return new CoroutineTracingDispatcher(instrumenters.stream()
-                .map(TracingInvocationInstrumenterFactory::newTracingInvocationInstrumenter)
-                .collect(Collectors.toList()));
+            .map(TracingInvocationInstrumenterFactory::newTracingInvocationInstrumenter)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
Fixes NPE in Core tests. `newTracingInvocationInstrumenter` is nullable and can return null.

```
	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: io.micronaut.http.bind.binders.DelegatingCoroutineContext@a6fd483
Caused by: java.lang.NullPointerException: Cannot invoke "io.micronaut.scheduling.instrument.InvocationInstrumenter.newInstrumentation()" because "p0" is null
	at io.micronaut.tracing.instrument.kotlin.CoroutineTracingDispatcher.updateThreadContext(CoroutineTracingDispatcher.kt:36)
	at io.micronaut.tracing.instrument.kotlin.CoroutineTracingDispatcher.updateThreadContext(CoroutineTracingDispatcher.kt:25)
	at kotlinx.coroutines.internal.ThreadContextKt$updateState$1.invoke(ThreadContext.kt:54)
	at kotlinx.coroutines.internal.ThreadContextKt$updateState$1.invoke(ThreadContext.kt:52)
	at kotlin.coroutines.CombinedContext.fold(CoroutineContextImpl.kt:131)
```