### PR TITLE
Change the HTTP server span naming

### DIFF
--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/MicronautHttpServerAttributesGetter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/MicronautHttpServerAttributesGetter.java
@@ -82,14 +82,17 @@ enum MicronautHttpServerAttributesGetter implements HttpServerAttributesGetter<H
 
     @Override
     public String getRoute(HttpRequest<Object> request) {
-        Optional<Object> routeInfo = request.getAttribute(HttpAttributes.ROUTE_INFO)
+        Optional<String> routeInfo = request.getAttribute(HttpAttributes.ROUTE_INFO)
             .filter(UriRouteMatch.class::isInstance)
             .map(ri -> (UriRouteMatch) ri)
             .map(UriRouteMatch::getRoute)
             .map(UriRoute::getUriMatchTemplate)
             .map(UriMatchTemplate::toPathString);
-        return routeInfo.map(Object::toString).orElseGet(() -> request.getAttribute(HttpAttributes.URI_TEMPLATE).map(Object::toString)
-            .orElse(request.getUri().toString()));
+        return routeInfo.orElseGet(() ->
+            request.getAttribute(HttpAttributes.URI_TEMPLATE)
+                .map(Object::toString)
+                .orElse(null)
+        );
     }
 
     @Override

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -245,9 +245,26 @@ class OpenTelemetryHttpSpec extends Specification {
         e.message == "Not Found"
         conditions.eventually {
             exporter.finishedSpanItems.size() == 1
-            exporter.finishedSpanItems[0].name == "GET $route"
+            exporter.finishedSpanItems[0].name == "GET"
             exporter.finishedSpanItems[0].status.statusCode == StatusCode.ERROR
         }
+        cleanup:
+        exporter.reset()
+    }
+
+    void 'test span name contains method'() {
+        given:
+        def exporter = embeddedServer.applicationContext.getBean(InMemorySpanExporter)
+        def warehouseClient = embeddedServer.applicationContext.getBean(WarehouseClient)
+
+        expect:
+        var uuid = UUID.randomUUID()
+        warehouseClient.order(uuid, UUID.randomUUID())
+
+        conditions.eventually {
+            exporter.finishedSpanItems.any(x -> x.name == "GET /client/order/{orderId}")
+        }
+
         cleanup:
         exporter.reset()
     }


### PR DESCRIPTION
## Description
Change the HTTP server span naming to be consistent with the opentelemetry specification

- The span `http.route` attribute is returned as null when no route was matched (see [HTTP server attributes specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions)).
- Because of the previous statement, the span name is just the method for unmatched paths.

Also: [OpenTelemetry reference](https://opentelemetry.io/docs/reference/specification/trace/api/#span)

## Example
After the change for these commands:
```shell
$ curl http://localhost:8080/store/inventory/laptop
{"warehouse":0,"item":"laptop","store":4}

$  curl http://localhost:8080/store/inventor
{"message":"Not Found","_links":{"self":{"href":"/store/inventor","templated":false}},"_embedded":{"errors":[{"message":"Page Not Found"}]}}
```
the spans look like:
![image](https://user-images.githubusercontent.com/80816836/233476642-034ae162-39b9-4a1d-893d-2aea4ebb02b5.png)

