### PR TITLE
Otel/zipkin exporter micronaut client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,8 @@ opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api' }
 opentelemetry-sdk = { module = 'io.opentelemetry:opentelemetry-sdk' }
 opentelemetry-sdk-testing = { module = 'io.opentelemetry:opentelemetry-sdk-testing' }
 opentelemetry-autoconfigure = { module = 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure' }
+opentelemetry-exporter-zipkin = { module = 'io.opentelemetry:opentelemetry-exporter-zipkin', version.ref = 'managed-opentelemetry' }
+
 opentelemetry-instrumentation-api = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api' }
 opentelemetry-instrumentation-grpc = { module = 'io.opentelemetry.instrumentation:opentelemetry-grpc-1.6'}
 opentelemetry-instrumentation-kafka-common = { module = 'io.opentelemetry.instrumentation:opentelemetry-kafka-clients-common'}

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ include 'tracing-opentelemetry-annotation'
 include 'tracing-opentelemetry-grpc'
 include 'tracing-opentelemetry-http'
 include 'tracing-opentelemetry-kafka'
+include 'tracing-opentelemetry-zipkin-exporter'
 
 // OpenTracing
 

--- a/src/main/docs/guide/opentelemetry/exporters.adoc
+++ b/src/main/docs/guide/opentelemetry/exporters.adoc
@@ -21,3 +21,18 @@ otel:
   traces:
     exporter: zipkin
 ----
+
+Micronaut provides Zipkin exporter that will use Micronaut's HTTP client instead of OKHttp client. That will reduce dependency graph and will make your native executable smaller. To use it add next dependency:
+
+dependency:micronaut-tracing-opentelemetry-zipkin-exporter[scope="implementation", groupId="io.micronaut.tracing"]
+
+To configure Micronaut Zipkin exporter add
+[configuration]
+----
+otel:
+  exporter:
+    zipkin:
+      url: <url-to-zipkin-server>
+----
+
+NOTE: Micronaut Zipkin exporter requires `otel.traces.exporter` property not to be defined to avoid conflicts with Open Telemetry default implementation of zipkin exporter.

--- a/tracing-opentelemetry-zipkin-exporter/build.gradle
+++ b/tracing-opentelemetry-zipkin-exporter/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'io.micronaut.build.internal.tracing-module'
+    alias libs.plugins.protobuf
+}
+
+dependencies {
+    implementation libs.opentelemetry.exporter.zipkin
+    implementation mn.micronaut.http.client
+    implementation mnReactor.micronaut.reactor
+    implementation platform (libs.boms.zipkin.reporter)
+    implementation libs.zipkin.reporter
+}

--- a/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/HttpClientOtelSenderConfiguration.java
+++ b/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/HttpClientOtelSenderConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.exporter.zipkin;
+
+import io.micronaut.context.annotation.ConfigurationBuilder;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.http.client.HttpClientConfiguration;
+
+import static io.micronaut.tracing.opentelemetry.exporter.zipkin.HttpClientOtelSenderConfiguration.PREFIX;
+
+/**
+ * Configuration properties for Zipkin exporter.
+ */
+@ConfigurationProperties(PREFIX)
+public class HttpClientOtelSenderConfiguration extends HttpClientConfiguration {
+
+    public static final String PREFIX =  "otel.exporter.zipkin";
+
+    @ConfigurationBuilder(prefixes = "")
+    protected final HttpClientSender.Builder clientSenderBuilder;
+
+    /**
+     * Initialize the builder with client configurations.
+     */
+    public HttpClientOtelSenderConfiguration() {
+        clientSenderBuilder = new HttpClientSender.Builder(this);
+    }
+
+    @Override
+    public ConnectionPoolConfiguration getConnectionPoolConfiguration() {
+        return new ConnectionPoolConfiguration();
+    }
+
+    /**
+     * Creates builder.
+     *
+     * @return the builder
+     */
+    public HttpClientSender.Builder getBuilder() {
+        return clientSenderBuilder;
+    }
+}

--- a/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/HttpClientSender.java
+++ b/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/HttpClientSender.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.exporter.zipkin;
+
+import io.micronaut.core.io.buffer.ByteBuffer;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.discovery.exceptions.NoAvailableServiceException;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.http.client.LoadBalancer;
+import io.micronaut.http.client.LoadBalancerResolver;
+import io.micronaut.http.client.netty.DefaultHttpClient;
+import jakarta.inject.Provider;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.Flux;
+import zipkin2.Call;
+import zipkin2.Callback;
+import zipkin2.CheckResult;
+import zipkin2.codec.Encoding;
+import zipkin2.reporter.Sender;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.micronaut.http.HttpRequest.POST;
+import static io.micronaut.http.HttpStatus.BAD_REQUEST;
+import static io.micronaut.http.HttpStatus.MULTIPLE_CHOICES;
+import static io.micronaut.tracing.opentelemetry.exporter.zipkin.ZipkinServiceInstanceList.SERVICE_ID;
+import static reactor.core.publisher.FluxSink.OverflowStrategy.BUFFER;
+import static zipkin2.CheckResult.OK;
+import static zipkin2.codec.Encoding.JSON;
+
+/**
+ * A {@code Sender} implementation that uses Micronaut's {@code HttpClient}.
+ *
+ * @author graemerocher
+ * @since 1.0
+ */
+public final class HttpClientSender extends Sender {
+
+    private final Encoding encoding;
+    private final int messageMaxBytes;
+    private final boolean compressionEnabled;
+    private final URI endpoint;
+    private final Provider<LoadBalancerResolver> loadBalancerResolver;
+    private final HttpClientConfiguration clientConfiguration;
+    private HttpClient httpClient;
+
+    private HttpClientSender(Encoding encoding,
+                             int messageMaxBytes,
+                             boolean compressionEnabled,
+                             HttpClientConfiguration clientConfiguration,
+                             Provider<LoadBalancerResolver> loadBalancerResolver,
+                             String path) {
+        this.loadBalancerResolver = loadBalancerResolver;
+        this.clientConfiguration = clientConfiguration;
+        this.encoding = encoding;
+        this.messageMaxBytes = messageMaxBytes;
+        this.compressionEnabled = compressionEnabled;
+        endpoint = path == null ? URI.create(Builder.DEFAULT_PATH) : URI.create(path);
+    }
+
+    @Override
+    public Encoding encoding() {
+        return encoding;
+    }
+
+    @Override
+    public int messageMaxBytes() {
+        return messageMaxBytes;
+    }
+
+    @Override
+    public int messageSizeInBytes(List<byte[]> encodedSpans) {
+        return encoding().listSizeInBytes(encodedSpans);
+    }
+
+    @Override
+    public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+        initHttpClient();
+        if (httpClient == null || !httpClient.isRunning()) {
+            throw new IllegalStateException("HTTP Client Closed");
+        }
+
+        return new HttpCall(httpClient, endpoint, compressionEnabled, encodedSpans);
+    }
+
+    @Override
+    public CheckResult check() {
+        initHttpClient();
+
+        if (httpClient == null) {
+            return CheckResult.failed(new NoAvailableServiceException(SERVICE_ID));
+        }
+
+        try {
+            HttpResponse<Object> response = httpClient
+                    .toBlocking()
+                    .exchange(POST(endpoint, Collections.emptyList()));
+            if (response.getStatus().getCode() >= MULTIPLE_CHOICES.getCode()) {
+                throw new IllegalStateException("check response failed: " + response);
+            }
+            return OK;
+        } catch (Exception e) {
+            return CheckResult.failed(e);
+        }
+    }
+
+    private void initHttpClient() {
+        if (httpClient != null) {
+            return;
+        }
+
+        Optional<? extends LoadBalancer> loadBalancer = loadBalancerResolver.get()
+                .resolve(SERVICE_ID);
+
+        httpClient = loadBalancer.map(lb ->
+            new DefaultHttpClient(lb, clientConfiguration)
+        ).orElse(null);
+    }
+
+    @Override
+    public void close() {
+        if (httpClient != null) {
+            httpClient.close();
+        }
+    }
+
+    /**
+     * The HTTP call.
+     */
+    private static class HttpCall extends Call<Void> {
+
+        private final HttpClient httpClient;
+        private final URI endpoint;
+        private final boolean compressionEnabled;
+        private final List<byte[]> encodedSpans;
+
+        private final AtomicReference<Subscription> subscription = new AtomicReference<>();
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        HttpCall(HttpClient httpClient,
+                 URI endpoint,
+                 boolean compressionEnabled,
+                 List<byte[]> encodedSpans) {
+            this.httpClient = httpClient;
+            this.endpoint = endpoint;
+            this.compressionEnabled = compressionEnabled;
+            this.encodedSpans = encodedSpans;
+        }
+
+        @Override
+        public Void execute() {
+            HttpResponse<Object> response = httpClient.toBlocking().exchange(prepareRequest());
+            if (response.getStatus().getCode() >= BAD_REQUEST.getCode()) {
+                throw new IllegalStateException("Response return invalid status code: " + response.getStatus());
+            }
+            return null;
+        }
+
+        @Override
+        public void enqueue(Callback<Void> callback) {
+            Publisher<HttpResponse<ByteBuffer>> publisher = httpClient.exchange(prepareRequest());
+            publisher.subscribe(new Subscriber<HttpResponse<ByteBuffer>>() {
+
+                @Override
+                public void onSubscribe(Subscription s) {
+                    subscription.set(s);
+                    s.request(1);
+                }
+
+                @Override
+                public void onNext(HttpResponse<ByteBuffer> response) {
+                    if (response.getStatus().getCode() >= BAD_REQUEST.getCode()) {
+                        callback.onError(new IllegalStateException("Response return invalid status code: " + response.getStatus()));
+                    } else {
+                        callback.onSuccess(null);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    callback.onError(t);
+                }
+
+                @Override
+                public void onComplete() {
+                }
+            });
+        }
+
+        @Override
+        public void cancel() {
+            Subscription s = subscription.get();
+            if (s != null) {
+                cancelled.set(true);
+                s.cancel();
+            }
+        }
+
+        @Override
+        public boolean isCanceled() {
+            Subscription s = subscription.get();
+            return s != null && cancelled.get();
+        }
+
+        @Override
+        public Call<Void> clone() {
+            // stateless. no need to clone
+            return new HttpCall(httpClient, endpoint, compressionEnabled, encodedSpans);
+        }
+
+        protected MutableHttpRequest<Flux<Object>> prepareRequest() {
+            return POST(endpoint, spanReactiveSequence());
+        }
+
+        private Flux<Object> spanReactiveSequence() {
+            return Flux.create(emitter -> {
+                for (byte[] encodedSpan : encodedSpans) {
+                    emitter.next(encodedSpan);
+                }
+                emitter.complete();
+            }, BUFFER);
+        }
+    }
+
+    /**
+     * Constructs the {@code HttpClientSender}.
+     */
+    public static class Builder {
+
+        public static final String DEFAULT_PATH = "/api/v2/spans";
+        public static final String DEFAULT_SERVER_URL = "http://localhost:9411";
+
+        private Encoding encoding = JSON;
+        private int messageMaxBytes = 5 * 1024;
+        private String path = DEFAULT_PATH;
+        private boolean compressionEnabled = true;
+        private List<URI> servers = Collections.singletonList(URI.create(DEFAULT_SERVER_URL));
+        private final HttpClientConfiguration clientConfiguration;
+
+        /**
+         * @param clientConfiguration the HTTP client configuration
+         */
+        public Builder(HttpClientConfiguration clientConfiguration) {
+            this.clientConfiguration = clientConfiguration;
+        }
+
+        /**
+         * @return the configured Zipkin servers
+         */
+        public List<URI> getServers() {
+            return servers;
+        }
+
+        /**
+         * The encoding to use. Defaults to {@link Encoding#JSON}
+         *
+         * @param encoding the encoding
+         * @return this
+         */
+        public Builder encoding(Encoding encoding) {
+            if (encoding != null) {
+                this.encoding = encoding;
+            }
+            return this;
+        }
+
+        /**
+         * The message max bytes.
+         *
+         * @param messageMaxBytes the max bytes
+         * @return this
+         */
+        public Builder messageMaxBytes(int messageMaxBytes) {
+            this.messageMaxBytes = messageMaxBytes;
+            return this;
+        }
+
+        /**
+         * Whether compression is enabled (defaults to true).
+         *
+         * @param compressionEnabled true if compression is enabled
+         * @return this
+         */
+        public Builder compressionEnabled(boolean compressionEnabled) {
+            this.compressionEnabled = compressionEnabled;
+            return this;
+        }
+
+        /**
+         * The endpoint to use.
+         *
+         * @param endpoint the fully qualified URI of the Zipkin endpoint
+         * @return this
+         */
+        public Builder server(URI endpoint) {
+            if (endpoint != null) {
+                servers = Collections.singletonList(endpoint);
+            }
+            return this;
+        }
+
+        /**
+         * The endpoint to use.
+         *
+         * @param endpoint the fully qualified URI of the Zipkin endpoint
+         * @return this
+         */
+        public Builder url(URI endpoint) {
+            return server(endpoint);
+        }
+
+        /**
+         * The endpoint to use.
+         *
+         * @param urls the Zipkin server URLs
+         * @return this
+         */
+        public Builder urls(List<URI> urls) {
+            if (CollectionUtils.isNotEmpty(urls)) {
+                servers = Collections.unmodifiableList(urls);
+            }
+            return this;
+        }
+
+        /**
+         * The path to use.
+         *
+         * @param path the path of the Zipkin endpoint
+         * @return this
+         */
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        /**
+         * Constructs a {@code HttpClientSender}.
+         *
+         * @param loadBalancerResolver resolver capable of resolving references
+         *                             to services into a concrete load-balancer
+         * @return the sender
+         */
+        public HttpClientSender build(Provider<LoadBalancerResolver> loadBalancerResolver) {
+            return new HttpClientSender(
+                    encoding,
+                    messageMaxBytes,
+                    compressionEnabled,
+                    clientConfiguration,
+                    loadBalancerResolver,
+                    path
+            );
+        }
+    }
+}

--- a/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactory.java
+++ b/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.exporter.zipkin;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.client.LoadBalancerResolver;
+import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import zipkin2.reporter.Sender;
+
+/**
+ * Builds a {@code SpanProcessor} that exports traces to Zipkin.
+ */
+@Factory
+public final class OtelHttpClientSenderFactory {
+    private final HttpClientOtelSenderConfiguration configuration;
+
+    /**
+     * @param configuration the HTTP client sender configurations
+     */
+    protected OtelHttpClientSenderFactory(HttpClientOtelSenderConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Singleton
+    @Requires(missingBeans = Sender.class)
+    public Sender zipkinSender(Provider<LoadBalancerResolver> loadBalancerResolver) {
+        return configuration.getBuilder()
+            .build(loadBalancerResolver);
+    }
+
+    @Singleton
+    public SpanProcessor createExporter(Sender sender) {
+        return BatchSpanProcessor.builder(ZipkinSpanExporter.builder().setSender(sender).build()).build();
+    }
+
+}
+

--- a/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactory.java
+++ b/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactory.java
@@ -29,6 +29,7 @@ import zipkin2.reporter.Sender;
  * Builds a {@code SpanProcessor} that exports traces to Zipkin.
  */
 @Factory
+@Requires(missingProperty = "otel.traces.exporter")
 public final class OtelHttpClientSenderFactory {
     private final HttpClientOtelSenderConfiguration configuration;
 

--- a/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/ZipkinServiceInstanceList.java
+++ b/tracing-opentelemetry-zipkin-exporter/src/main/java/io/micronaut/tracing/opentelemetry/exporter/zipkin/ZipkinServiceInstanceList.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.exporter.zipkin;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.ServiceInstance;
+import io.micronaut.discovery.ServiceInstanceList;
+import jakarta.inject.Singleton;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A {@code ServiceInstanceList} for Zipkin.
+ *
+ * @author graemerocher
+ * @since 1.0
+ */
+@Singleton
+@Requires(beans = HttpClientOtelSenderConfiguration.class)
+public class ZipkinServiceInstanceList implements ServiceInstanceList {
+
+    public static final String SERVICE_ID = "zipkin";
+
+    private final HttpClientOtelSenderConfiguration configuration;
+
+    /**
+     * Create a {@code ServiceInstanceList} for Zipkin with existing configuration.
+     *
+     * @param configuration used to configure HTTP trace sending under the {@code tracing.zipkin.http} namespace.
+     */
+    public ZipkinServiceInstanceList(HttpClientOtelSenderConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String getID() {
+        return SERVICE_ID;
+    }
+
+    @Override
+    public List<ServiceInstance> getInstances() {
+        List<URI> servers = configuration.getBuilder().getServers();
+        return servers.stream()
+                .map(uri -> ServiceInstance.builder(SERVICE_ID, uri).build())
+                .collect(Collectors.toList());
+    }
+}

--- a/tracing-opentelemetry-zipkin-exporter/src/test/groovy/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactorySpec.groovy
+++ b/tracing-opentelemetry-zipkin-exporter/src/test/groovy/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactorySpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.tracing.opentelemetry.exporter.zipkin
+
+
+import io.micronaut.context.BeanContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.opentelemetry.sdk.trace.SpanProcessor
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import jakarta.inject.Inject
+import spock.lang.Specification
+import zipkin2.reporter.Sender
+
+
+@MicronautTest(startApplication = false)
+class OtelHttpClientSenderFactorySpec extends Specification {
+
+    @Inject
+    BeanContext beanContext
+
+    void "if you have micronaut otel Zipkin export module verify that Sender and SpanProcessor exists"() {
+
+        expect:
+        beanContext.containsBean(Sender)
+        beanContext.containsBean(SpanProcessor)
+
+        when:
+        Sender sender = beanContext.getBean(Sender)
+        SpanProcessor spanProcessor = beanContext.getBean(SpanProcessor)
+
+        then:
+        sender instanceof HttpClientSender
+        spanProcessor instanceof BatchSpanProcessor
+    }
+}


### PR DESCRIPTION
Pr adds new module: `tracing-opentelemetry-zipkin-exporter`. 

If new module is on classpath of an application it will create Zipkin exporter that will use Micronaut Http client. It requires `otel.traces.exporter` not to be set to avoid conflicts with OTEL default Zipkin exporter implementation.