### PR TITLE
Fix for http status code attribute not being set for errors when tracing with opentelemetry (#410)

### DIFF
--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -93,25 +93,26 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
             return Mono.from(chain.proceed(request))
                 .doOnNext(mutableHttpResponse -> mutableHttpResponse.getAttribute(HttpAttributes.EXCEPTION, Exception.class)
                     .ifPresentOrElse(
-                        e -> onError(request, context, e), () -> {
+                        e -> onError(request, context, mutableHttpResponse, e), () -> {
                             if (mutableHttpResponse.status().getCode() >= 400) {
-                                onError(request, context, null);
+                                onError(request, context, mutableHttpResponse,null);
                             } else {
                                 instrumenter.end(context, request, mutableHttpResponse, null);
                             }
                         }))
-                .doOnError(throwable -> onError(request, context, throwable))
+                .doOnError(throwable -> onError(request, context, null, throwable))
                 .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
         }
     }
 
-    private void onError(HttpRequest<?> request, Context context, @Nullable Throwable e) {
+    private void onError(HttpRequest<?> request, Context context,
+                         MutableHttpResponse<?> mutableHttpResponse, @Nullable Throwable e) {
         Span span = Span.fromContext(context);
         if (e != null) {
             span.recordException(e);
         }
         span.setStatus(StatusCode.ERROR);
-        instrumenter.end(context, request, null, e);
+        instrumenter.end(context, request, mutableHttpResponse, e);
         request.setAttribute(CONTINUE, true);
     }
 }

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -106,7 +106,7 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
     }
 
     private void onError(HttpRequest<?> request, Context context,
-                         MutableHttpResponse<?> mutableHttpResponse, @Nullable Throwable e) {
+                         @Nullable MutableHttpResponse<?> mutableHttpResponse, @Nullable Throwable e) {
         Span span = Span.fromContext(context);
         if (e != null) {
             span.recordException(e);


### PR DESCRIPTION
The fix consists in passing the `mutableHttpResponse` when calling `instrumenter.end` even when we have an exception. I've checked that this was done on previous versions (4.6.0).

I have also added / improved some tests to guarantee the most important http semantic attributes are set.