### PR TITLE
Use compileOnly scope for grpc/http/kafka dependencies.

### DIFF
--- a/tracing-opentelemetry-grpc/build.gradle
+++ b/tracing-opentelemetry-grpc/build.gradle
@@ -9,7 +9,8 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation)
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api mn.micronaut.core.processor
-    compileOnly mnGrpc.micronaut.grpc.client.runtime
+    compileOnly(mnGrpc.micronaut.grpc.client.runtime)
+    testImplementation(mnGrpc.micronaut.grpc.client.runtime)    
     compileOnly(mnGrpc.micronaut.grpc.server.runtime)
     testImplementation(mnGrpc.micronaut.grpc.server.runtime)
     api projects.micronautTracingAnnotation

--- a/tracing-opentelemetry-grpc/build.gradle
+++ b/tracing-opentelemetry-grpc/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation)
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api mn.micronaut.core.processor
-    api mnGrpc.micronaut.grpc.client.runtime
-    api mnGrpc.micronaut.grpc.server.runtime
+    compileOnly mnGrpc.micronaut.grpc.client.runtime
+    compileOnly mnGrpc.micronaut.grpc.server.runtime
     api projects.micronautTracingAnnotation
     api projects.micronautTracingOpentelemetry
     api libs.opentelemetry.api

--- a/tracing-opentelemetry-grpc/build.gradle
+++ b/tracing-opentelemetry-grpc/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api mn.micronaut.core.processor
     compileOnly mnGrpc.micronaut.grpc.client.runtime
-    compileOnly mnGrpc.micronaut.grpc.server.runtime
+    compileOnly(mnGrpc.micronaut.grpc.server.runtime)
+    testImplementation(mnGrpc.micronaut.grpc.server.runtime)
     api projects.micronautTracingAnnotation
     api projects.micronautTracingOpentelemetry
     api libs.opentelemetry.api

--- a/tracing-opentelemetry-http/build.gradle
+++ b/tracing-opentelemetry-http/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation)
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api mn.micronaut.core.processor
-    api mn.micronaut.http.client
+    compileOnly mn.micronaut.http.client
     api mn.micronaut.router
     api projects.micronautTracingAnnotation
     api projects.micronautTracingOpentelemetry

--- a/tracing-opentelemetry-http/build.gradle
+++ b/tracing-opentelemetry-http/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation)
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api mn.micronaut.core.processor
-    compileOnly mn.micronaut.http.client
     api mn.micronaut.router
     api projects.micronautTracingAnnotation
     api projects.micronautTracingOpentelemetry

--- a/tracing-opentelemetry-kafka/build.gradle
+++ b/tracing-opentelemetry-kafka/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api projects.micronautTracingOpentelemetry
     api libs.opentelemetry.api
-    compileOnly mnKafka.micronaut.kafka
+    api(mnKafka.micronaut.kafka)
     api libs.opentelemetry.instrumentation.api.semconv
     api libs.opentelemetry.instrumentation.kafka.common
 

--- a/tracing-opentelemetry-kafka/build.gradle
+++ b/tracing-opentelemetry-kafka/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api projects.micronautTracingOpentelemetry
     api libs.opentelemetry.api
-    api mnKafka.micronaut.kafka
+    compileOnly mnKafka.micronaut.kafka
     api libs.opentelemetry.instrumentation.api.semconv
     api libs.opentelemetry.instrumentation.kafka.common
 


### PR DESCRIPTION
Hi!

I encountered one problem. I have a CLI application, that uses grpc as a client, after adding `micronaut-tracing-opentelemetry-grpc` dependency I see that grpc server dependency was also added to my classpath and grpc server started initializing at the startup. Of course can exclude that particular dependency, but it looks like a better way to not automatically add the to the classpath and initialize tracing for them only of these dependencies are available on the classpath.