### PR TITLE
Demonstrate bug: span hierarchy is incorrect when client call is nested within an internal span

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.3.3"
+micronaut = "4.3.5"
 micronaut-test = "4.2.0"
 micronaut-logging = "1.2.2"
 micronaut-platform = "4.2.3"

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingExclusionSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingExclusionSpec.groovy
@@ -11,7 +11,6 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.opentracing.Tracer
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -513,7 +512,6 @@ class HttpTracingExclusionSpec extends Specification {
         }
     }
 
-    @PendingFeature
     void 'test continue nested HTTP tracing - reactive'() {
         when:
         HttpResponse<String> response = client.toBlocking().exchange('/traced/nestedReactive/John', String)

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -27,7 +27,6 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -629,7 +628,6 @@ class HttpTracingSpec extends Specification {
         }
     }
 
-    @PendingFeature
     void 'test continue nested HTTP tracing - reactive'() {
         when:
         HttpResponse<String> response = client.toBlocking().exchange('/traced/nestedReactive/John', String)

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -27,6 +27,7 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 import spock.lang.AutoCleanup
+import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -628,6 +629,7 @@ class HttpTracingSpec extends Specification {
         }
     }
 
+    @PendingFeature
     void 'test continue nested HTTP tracing - reactive'() {
         when:
         HttpResponse<String> response = client.toBlocking().exchange('/traced/nestedReactive/John', String)


### PR DESCRIPTION
Only the very last commit is relevant for the bug itself, I needed to merge in a couple other pending changes though to be able to demonstrate this.

First, I thought that this might be an issue with incorrect tracing implementation of either the `@NewSpan` or the declarative HTTP client, but then I created a similar test for Jaeger tracing, and the exact same problem is present there.

This is how far I got in trying to figure out where it goes wrong:
* When the reactive Mono of the internal worker is returned, the HTTP filter chain is not assembled yet for the outgoing client call.
* Upon calling `Mono.toFuture()` in the controller method the initialization of the client filter chain is triggered and for some reason it uses the current span context (which is the top-level server span) instead of the internal span.
* When the implementation of the worker method annotated with `@NewSpan` starts with the downstream call instead of the `Mono.just`, then the correct span context is captured as the parent of the client span of the outgoing call.

If we return a `Mono` in the controller method instead of converting it to `CompletableFuture` the span hierarchy is captured correctly. However, when using [micronaut-graphql](https://micronaut-projects.github.io/micronaut-graphql/latest/guide/index.html) integration we need to return `CompletableFuture`-s.