### PR TITLE
Upgrade Open Telemetry to 1.36

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=6.4.2-SNAPSHOT
+projectVersion=7.0.0-SNAPSHOT
 projectGroup=io.micronaut.tracing
 
 title=Micronaut Tracing

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,18 +7,18 @@ micronaut-docs = '2.0.0'
 groovy = "4.0.17"
 spock = "2.3-groovy-4.0"
 
-managed-brave-instrumentation = '5.18.1'
-managed-opentelemetry = '1.32.0'
-managed-opentelemetry-alpha = '1.31.0-alpha'
-managed-opentelemetry-instrumentation = '1.31.0'
-managed-opentelemetry-instrumentation-alpha = '1.31.0-alpha'
+managed-brave-instrumentation = '6.0.2'
+managed-opentelemetry = '1.36.0'
+managed-opentelemetry-alpha = '1.36.0-alpha'
+managed-opentelemetry-instrumentation = '1.33.1'
+managed-opentelemetry-instrumentation-alpha = '1.33.1-alpha'
 managed-opentelemetry-contrib-aws-xray = '1.32.0'
 managed-opentelemetry-contrib-aws-resources = '1.31.0-alpha'
 managed-opentelemetry-gcp-trace = '0.27.0-alpha'
 managed-opentelemetry-semconv = '1.21.0-alpha'
 managed-protobuf = '0.9.4'
-managed-zipkin = '2.27.1'
-managed-zipkin-reporter = '2.17.2'
+managed-zipkin = '3.1.1'
+managed-zipkin-reporter = '3.3.0'
 
 managed-jaeger = '1.8.1'
 managed-opentracing = '0.33.0'
@@ -75,6 +75,7 @@ protoc = { module = 'com.google.protobuf:protoc', version.ref = 'protobuf' }
 protoc-grpc = { module = 'io.grpc:protoc-gen-grpc-java', version.ref = 'grpc' }
 zipkin = { module = 'io.zipkin.zipkin2:zipkin', version.ref = 'managed-zipkin' }
 zipkin-reporter = { module = 'io.zipkin.reporter2:zipkin-reporter' }
+zipkin-reporter-brave = { module = 'io.zipkin.reporter2:zipkin-reporter-brave' }
 
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api' }
 opentelemetry-api-events = { module = 'io.opentelemetry:opentelemetry-api-events' }

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -12,3 +12,20 @@ The Micronaut Tracing Zipkin module (`io.micronaut.tracing:micronaut-tracing-zip
 - Micronaut Tracing Brave HTTP (`io.micronaut.tracing:micronaut-tracing-brave-http`)
 
 if you are using OpenTracing and Micronaut Tracing Zipkin module, you have to change `io.micronaut.tracing:micronaut-tracing-zipkin` dependency to `io.micronaut.tracing:micronaut-tracing-brave-http`. The Micronaut Tracing Brave HTTP brings HTTP filters for auto instrumentation of your requests. If you don't need HTTP filters you can only add `io.micronaut.tracing:micronaut-tracing-brave` dependency.
+
+== Micronaut Tracing 7.0.0 Breaking changes
+
+The following dependencies have been updated:
+
+- Open Telemetry 1.36
+- Open Telemetry Instrumentation 1.33.1
+
+The Open Telemetry updates required updating the following Zipkin dependencies to a new major version:
+
+- Zipkin Reporter 3.3.0
+- Zipkin Brave 6.0.2
+
+The only change due to the above dependency updates that might affect end user code is that the `errorParser` property has been removed from `io.micronaut.tracing.brave.BraveTracerConfiguration` as the `brave.ErrorParser` type no longer exists.
+
+The `io.micronaut.tracing.zipkin.http.client.HttpClientSender` class is now deprecated as it implements a deprecated Zipkin API. This class will be replaced with an implementation based on the Zipkin 3 APIs in a future release.
+

--- a/tracing-bom/build.gradle
+++ b/tracing-bom/build.gradle
@@ -44,10 +44,11 @@ micronautBom {
                         "io.zipkin.proto3"
                 ] as Set
         )
-        dependencies.add("io.opentelemetry:opentelemetry-bom:1.31.0")
-        dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.31.0-alpha")
-        dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:1.31.0")
-        dependencies.add("io.zipkin.brave:brave-instrumentation-benchmarks:5.18.1")
-        dependencies.add("io.zipkin.reporter2:zipkin-reporter-bom:2.17.2")
+        dependencies.add("io.opentelemetry:opentelemetry-bom:1.36.0")
+        dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.36.0-alpha")
+        dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:1.33.1")
+        dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.33.1-alpha")
+        dependencies.add("io.zipkin.brave:brave-instrumentation-benchmarks:6.0.2")
+        dependencies.add("io.zipkin.reporter2:zipkin-reporter-bom:3.3.0")
     }
 }

--- a/tracing-brave/build.gradle
+++ b/tracing-brave/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api platform (libs.boms.brave)
     api platform (libs.boms.zipkin.reporter)
     api libs.zipkin.reporter
+    api libs.zipkin.reporter.brave
     api libs.brave.opentracing
 
     testRuntimeOnly mnSerde.micronaut.serde.jackson

--- a/tracing-brave/src/main/java/io/micronaut/tracing/brave/BraveTracerConfiguration.java
+++ b/tracing-brave/src/main/java/io/micronaut/tracing/brave/BraveTracerConfiguration.java
@@ -16,7 +16,6 @@
 package io.micronaut.tracing.brave;
 
 import brave.Clock;
-import brave.ErrorParser;
 import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
@@ -54,7 +53,7 @@ public class BraveTracerConfiguration implements Toggleable {
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_ENABLED = false;
 
-    @ConfigurationBuilder(prefixes = "", excludes = {"errorParser", "clock", "endpoint", "spanReporter", "propagationFactory", "currentTraceContext", "sampler"})
+    @ConfigurationBuilder(prefixes = "", excludes = {"clock", "endpoint", "spanReporter", "propagationFactory", "currentTraceContext", "sampler"})
     protected Tracing.Builder tracingBuilder = Tracing.newBuilder();
 
     private boolean enabled = DEFAULT_ENABLED;
@@ -114,16 +113,6 @@ public class BraveTracerConfiguration implements Toggleable {
     public void setSampler(@Nullable Sampler sampler) {
         if (sampler != null) {
             tracingBuilder.sampler(sampler);
-        }
-    }
-
-    /**
-     * @param errorParser the parser
-     */
-    @Inject
-    public void setErrorParser(@Nullable ErrorParser errorParser) {
-        if (errorParser != null) {
-            tracingBuilder.errorParser(errorParser);
         }
     }
 

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/MicronautHttpClientAttributesGetter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/MicronautHttpClientAttributesGetter.java
@@ -15,9 +15,6 @@
  */
 package io.micronaut.tracing.opentelemetry.instrument.http.client;
 
-import java.util.List;
-import java.util.Map;
-
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
@@ -25,11 +22,13 @@ import io.micronaut.http.HttpVersion;
 import io.micronaut.http.MutableHttpRequest;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesGetter;
 
+import java.util.List;
+import java.util.Map;
+
 import static io.micronaut.http.HttpAttributes.SERVICE_ID;
 import static io.micronaut.http.HttpVersion.HTTP_1_0;
 import static io.micronaut.http.HttpVersion.HTTP_1_1;
 import static io.micronaut.http.HttpVersion.HTTP_2_0;
-import static io.opentelemetry.semconv.SemanticAttributes.NetTransportValues.IP_TCP;
 
 @Internal
 enum MicronautHttpClientAttributesGetter implements HttpClientAttributesGetter<MutableHttpRequest<Object>, HttpResponse<Object>> {
@@ -81,10 +80,5 @@ enum MicronautHttpClientAttributesGetter implements HttpClientAttributesGetter<M
     @Nullable
     public Integer getServerPort(MutableHttpRequest<Object> request) {
         return request.getServerAddress().getPort();
-    }
-
-    @Override
-    public String getTransport(MutableHttpRequest<Object> request, @Nullable HttpResponse<Object> response) {
-        return IP_TCP;
     }
 }

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -95,7 +95,7 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
                     .ifPresentOrElse(
                         e -> onError(request, context, mutableHttpResponse, e), () -> {
                             if (mutableHttpResponse.status().getCode() >= 400) {
-                                onError(request, context, mutableHttpResponse,null);
+                                onError(request, context, mutableHttpResponse, null);
                             } else {
                                 instrumenter.end(context, request, mutableHttpResponse, null);
                             }

--- a/tracing-opentelemetry-kafka/build.gradle
+++ b/tracing-opentelemetry-kafka/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api projects.micronautTracingOpentelemetry
     api libs.opentelemetry.api
     api(mnKafka.micronaut.kafka)
-    api libs.opentelemetry.instrumentation.api.semconv
+    api libs.opentelemetry.instrumentation.semconv
     api libs.opentelemetry.instrumentation.kafka.common
 
     testImplementation mnSerde.micronaut.serde.jackson

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryBuilder.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryBuilder.java
@@ -15,11 +15,6 @@
  */
 package io.micronaut.tracing.opentelemetry.instrument.kafka;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.CollectionUtils;
@@ -27,12 +22,15 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaProducerRequest;
-
 import org.apache.kafka.clients.producer.RecordMetadata;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import static io.micronaut.tracing.opentelemetry.instrument.kafka.KafkaAttributesExtractorUtils.putAttributes;
 

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryBuilder.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryBuilder.java
@@ -119,7 +119,7 @@ public final class KafkaTelemetryBuilder {
         return new KafkaTelemetry(
             openTelemetry,
             instrumenterFactory.createProducerInstrumenter(producerAttributesExtractors),
-            instrumenterFactory.createConsumerOperationInstrumenter(MessageOperation.RECEIVE, consumerAttributesExtractors),
+            instrumenterFactory.createConsumerProcessInstrumenter(consumerAttributesExtractors),
             producerTracingFilters, consumerTracingFilters, kafkaTelemetryConfiguration,
             propagationEnabled);
     }

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryIntegrationSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryIntegrationSpec.groovy
@@ -36,7 +36,7 @@ class KafkaTelemetryIntegrationSpec extends Specification {
             kafkaListener.text.size() == 1
             exporter.getFinishedSpanItems().size() == 2
             exporter.finishedSpanItems.name.any(x -> x.contains("publish"))
-            exporter.finishedSpanItems.name.any(x -> x.contains("receive"))
+            exporter.finishedSpanItems.name.any(x -> x.contains("process"))
         }
 
         cleanup:

--- a/tracing-opentelemetry/build.gradle
+++ b/tracing-opentelemetry/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     api libs.opentelemetry.api.events
     api libs.opentelemetry.instrumentation.annotations
     api libs.opentelemetry.instrumentation.api
-    api libs.opentelemetry.instrumentation.api.semconv
     api libs.opentelemetry.instrumentation.semconv
     api libs.opentelemetry.autoconfigure
 

--- a/tracing-zipkin-http-client/src/main/java/io/micronaut/tracing/zipkin/http/client/HttpClientSender.java
+++ b/tracing-zipkin-http-client/src/main/java/io/micronaut/tracing/zipkin/http/client/HttpClientSender.java
@@ -54,7 +54,9 @@ import static reactor.core.publisher.FluxSink.OverflowStrategy.BUFFER;
  *
  * @author graemerocher
  * @since 1.0
+ * @deprecated This class uses deprecated Zipkin 2 APIs and will be replaced by a Zipkin 3 based implementation in a future release.
  */
+@Deprecated(since = "7.0.0")
 public final class HttpClientSender extends Sender {
 
     private final Encoding encoding;

--- a/tracing-zipkin-http-client/src/main/java/io/micronaut/tracing/zipkin/http/client/HttpClientSender.java
+++ b/tracing-zipkin-http-client/src/main/java/io/micronaut/tracing/zipkin/http/client/HttpClientSender.java
@@ -30,10 +30,10 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.CheckResult;
-import zipkin2.codec.Encoding;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
 import zipkin2.reporter.Sender;
 
 import java.net.URI;
@@ -48,8 +48,6 @@ import static io.micronaut.http.HttpStatus.BAD_REQUEST;
 import static io.micronaut.http.HttpStatus.MULTIPLE_CHOICES;
 import static io.micronaut.tracing.zipkin.http.client.HttpClientSender.Builder.DEFAULT_PATH;
 import static reactor.core.publisher.FluxSink.OverflowStrategy.BUFFER;
-import static zipkin2.CheckResult.OK;
-import static zipkin2.codec.Encoding.JSON;
 
 /**
  * A {@code Sender} implementation that uses Micronaut's {@code HttpClient}.
@@ -121,7 +119,7 @@ public final class HttpClientSender extends Sender {
             if (response.getStatus().getCode() >= MULTIPLE_CHOICES.getCode()) {
                 throw new IllegalStateException("check response failed: " + response);
             }
-            return OK;
+            return CheckResult.OK;
         } catch (Exception e) {
             return CheckResult.failed(e);
         }
@@ -255,7 +253,7 @@ public final class HttpClientSender extends Sender {
         public static final String DEFAULT_PATH = "/api/v2/spans";
         public static final String DEFAULT_SERVER_URL = "http://localhost:9411";
 
-        private Encoding encoding = JSON;
+        private Encoding encoding = Encoding.JSON;
         private int messageMaxBytes = 5 * 1024;
         private String path = DEFAULT_PATH;
         private boolean compressionEnabled = true;


### PR DESCRIPTION
The main Open Telemetry BOM dependency is updated to 1.3.6. This has a cascading effect as it requires updating the Open Telemetry instrumentation libraries to 1.31, and the Zipkin dependencies to 3.x. Minor changes are implemented in the codebase to work with these dependency updates.

Since the required Zipkin update is to a new major version, the module version is bumped to 7.0.0.

This would supersede various open dependabot PRs for individual updates to these dependencies.
