### PR TITLE
bug: opentelemetry-exporter-jaeger gone

### DIFF
--- a/src/main/docs/guide/opentelemetry/exporters.adoc
+++ b/src/main/docs/guide/opentelemetry/exporters.adoc
@@ -6,33 +6,5 @@ For each exporter that you want to use you have to specify it inside configurati
 dependency:opentelemetry-exporter-otlp[scope="implementation", groupId="io.opentelemetry"]
 - Logging exporter: `logging`
 dependency:opentelemetry-exporter-logging[scope="implementation", groupId="io.opentelemetry"]
-- Jaeger exporter: `jaeger`
-dependency:opentelemetry-exporter-jaeger[scope="implementation", groupId="io.opentelemetry"]
 - Google Cloud Trace: `google_cloud_trace`
 dependency:exporter-auto[scope="implementation", groupId="com.google.cloud.opentelemetry"]
-- Zipkin exporter: `zipkin`
-dependency:opentelemetry-exporter-zipkin[scope="implementation", groupId="io.opentelemetry"]
-
-Example configuration for the Zipkin exporter:
-
-[configuration]
-----
-otel:
-  traces:
-    exporter: zipkin
-----
-
-Micronaut provides Zipkin exporter that will use Micronaut's HTTP client instead of OKHttp client. That will reduce dependency graph and will make your native executable smaller. To use it add next dependency:
-
-dependency:micronaut-tracing-opentelemetry-zipkin-exporter[scope="implementation", groupId="io.micronaut.tracing"]
-
-To configure Micronaut Zipkin exporter add
-[configuration]
-----
-otel:
-  exporter:
-    zipkin:
-      url: <url-to-zipkin-server>
-----
-
-NOTE: Micronaut Zipkin exporter requires `otel.traces.exporter` property not to be defined to avoid conflicts with Open Telemetry default implementation of zipkin exporter.

--- a/src/main/docs/guide/opentelemetry/exporters/exporterjaeger.adoc
+++ b/src/main/docs/guide/opentelemetry/exporters/exporterjaeger.adoc
@@ -1,0 +1,21 @@
+For Jaeger export use the OpenTelemetry Protocol exporter: `otlp` with the following dependency:
+
+dependency:opentelemetry-exporter-otlp[scope="implementation", groupId="io.opentelemetry"]
+
+IMPORTANT: The latest binary release of the OpenTelemetry Collector no longer includes exporters for the native Jaeger format.
+https://opentelemetry.io/blog/2023/jaeger-exporter-collector-migration/[Jaeger has support for OTLP out of the box]. If you had in your application the dependency `io.opentelemetry:opentelemetry-exporter-jaeger` replace it with `io.opentelemetry:opentelemetry-exporter-otlp`. Also, in your application configuration, replace `otel.tracer.exporter=jaeger` with `otel.tracer.exporter=otlp` and supply the otlp endpoint.
+
+To configure Micronaut Tracing for OpenTelemetry OTLP exporter and Jager, add the following configuration:
+[configuration]
+----
+otel:
+  traces:
+    exporter: otlp
+  exporter:
+    otlp:
+      endpoint: http://localhost:4317
+----
+
+In the previous configuration snippet, replace `http://localhost:4317` with your Jaeger endpoint.
+
+Checkout the guide https://guides.micronaut.io/latest/micronaut-microservices-distributed-tracing-jaeger-opentelemetry.html[Use OpenTelemetry with Jaeger and the Micronaut Framework for Microservice distributed tracing].

--- a/src/main/docs/guide/opentelemetry/exporters/exporterzipkin.adoc
+++ b/src/main/docs/guide/opentelemetry/exporters/exporterzipkin.adoc
@@ -1,0 +1,26 @@
+- Zipkin exporter: `zipkin`
+dependency:opentelemetry-exporter-zipkin[scope="implementation", groupId="io.opentelemetry"]
+
+Example configuration for the Zipkin exporter:
+
+[configuration]
+----
+otel:
+  traces:
+    exporter: zipkin
+----
+
+Micronaut provides Zipkin exporter that will use Micronaut's HTTP client instead of OKHttp client. That will reduce dependency graph and will make your native executable smaller. To use it add next dependency:
+
+dependency:micronaut-tracing-opentelemetry-zipkin-exporter[scope="implementation", groupId="io.micronaut.tracing"]
+
+To configure Micronaut Zipkin exporter add
+[configuration]
+----
+otel:
+  exporter:
+    zipkin:
+      url: <url-to-zipkin-server>
+----
+
+NOTE: Micronaut Zipkin exporter requires `otel.traces.exporter` property not to be defined to avoid conflicts with Open Telemetry default implementation of zipkin exporter.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -7,7 +7,10 @@ zipkin: Tracing with Zipkin
 opentelemetry:
   title: Tracing with OpenTelemetry
   annotations: OpenTelemetry Annotations
-  exporters: OpenTelemetry Exporters
+  exporters:
+    title: OpenTelemetry Exporters
+    exporterjaeger: OpenTelemetry Jaeger Exporter
+    exporterzipkin: OpenTelemetry Zipkin Exporter
   propagators: OpenTelemetry Propagators
   idgenerator: ID Generator
   http: HTTP Server and Client


### PR DESCRIPTION
Jaeger supports OTLP out-of-the-box. see: https://opentelemetry.io/blog/2023/jaeger-exporter-collector-migration/