### PR TITLE
test: adds a test-suite-xray module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,8 @@ opentelemetry-sdk = { module = 'io.opentelemetry:opentelemetry-sdk' }
 opentelemetry-sdk-testing = { module = 'io.opentelemetry:opentelemetry-sdk-testing' }
 opentelemetry-autoconfigure = { module = 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure' }
 opentelemetry-exporter-zipkin = { module = 'io.opentelemetry:opentelemetry-exporter-zipkin', version.ref = 'managed-opentelemetry' }
-
+opentelemetry-exporter-otlp = { module = 'io.opentelemetry:opentelemetry-exporter-otlp'}
+opentelemetry-extension-aws = { module = 'io.opentelemetry:opentelemetry-extension-aws' }
 opentelemetry-instrumentation-api = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api' }
 opentelemetry-instrumentation-grpc = { module = 'io.opentelemetry.instrumentation:opentelemetry-grpc-1.6'}
 opentelemetry-instrumentation-kafka-common = { module = 'io.opentelemetry.instrumentation:opentelemetry-kafka-clients-common'}
@@ -92,6 +93,9 @@ opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrum
 opentelemetry-aws-sdk = { module = 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2' }
 
 awssdk-core = { module = 'software.amazon.awssdk:sdk-core' }
+
+junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 
 # BOMs
 boms-opentelemetry = { module = 'io.opentelemetry:opentelemetry-bom', version.ref = 'managed-opentelemetry' }

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include 'tracing-brave-http'
 
 include 'tests:kotlin-tests'
 include 'test-suite-java'
+include 'test-suite-opentelemetry-xray'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 

--- a/test-suite-opentelemetry-xray/build.gradle.kts
+++ b/test-suite-opentelemetry-xray/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("java-library")
+}
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testRuntimeOnly(mnLogging.logback.classic)
+
+    testImplementation(projects.micronautTracingOpentelemetryHttp)
+    testImplementation(libs.opentelemetry.exporter.otlp)
+    testImplementation(libs.opentelemetry.aws.sdk)
+    testImplementation(libs.opentelemetry.extension.aws)
+
+    testRuntimeOnly(libs.junit.engine)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+}
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+java {
+    sourceCompatibility = JavaVersion.toVersion("17")
+    targetCompatibility = JavaVersion.toVersion("17")
+}

--- a/test-suite-opentelemetry-xray/src/test/java/io.micronaut.tracing.opentelementry.xray.test/OpenTelemetryExclusionsConfigurationTest.java
+++ b/test-suite-opentelemetry-xray/src/test/java/io.micronaut.tracing.opentelementry.xray.test/OpenTelemetryExclusionsConfigurationTest.java
@@ -1,0 +1,28 @@
+package io.micronaut.tracing.opentelementry.xray.test;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.micronaut.core.convert.format.MapFormat.MapTransformation.FLAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class OpenTelemetryExclusionsConfigurationTest {
+
+    @Test
+    void possibleToRetrieveConfiguration(@Property(name = "otel") @MapFormat(transformation = FLAT) Map<String, String> otelConfig) {
+        Map<String, String> otel = otelConfig.entrySet().stream().collect(Collectors.toMap(
+                e -> "otel." + e.getKey(),
+                Map.Entry::getValue
+        ));
+        assertEquals("/health", otel.get("otel.traces.exclusions"));
+        assertEquals("tracecontext, baggage, xray", otel.get("otel.traces.propagator"));
+        assertEquals("otlp", otel.get("otel.traces.exporter"));
+
+    }
+}

--- a/test-suite-opentelemetry-xray/src/test/resources/application.properties
+++ b/test-suite-opentelemetry-xray/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+otel.traces.exporter=otlp
+otel.traces.propagator=tracecontext, baggage, xray
+otel.traces.exclusions=/health


### PR DESCRIPTION
This adds a test-suite-xray module to verify the following dependencies are resolvables without specifying the version:

```
io.opentelemetry:opentelemetry-exporter-otlp
io.opentelemetry:opentelemetry-extension-aws
io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2
```