### PR TITLE
bug: replace opentelemetry-sdk-extension-aws mentions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,7 +80,8 @@ opentelemetry-sdk = { module = 'io.opentelemetry:opentelemetry-sdk' }
 opentelemetry-sdk-testing = { module = 'io.opentelemetry:opentelemetry-sdk-testing' }
 opentelemetry-autoconfigure = { module = 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure' }
 opentelemetry-exporter-zipkin = { module = 'io.opentelemetry:opentelemetry-exporter-zipkin', version.ref = 'managed-opentelemetry' }
-
+opentelemetry-exporter-otlp = { module = 'io.opentelemetry:opentelemetry-exporter-otlp'}
+opentelemetry-extension-aws = { module = 'io.opentelemetry:opentelemetry-extension-aws' }
 opentelemetry-instrumentation-api = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api' }
 opentelemetry-instrumentation-grpc = { module = 'io.opentelemetry.instrumentation:opentelemetry-grpc-1.6'}
 opentelemetry-instrumentation-kafka-common = { module = 'io.opentelemetry.instrumentation:opentelemetry-kafka-clients-common'}
@@ -90,6 +91,9 @@ opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrum
 opentelemetry-aws-sdk = { module = 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2' }
 
 awssdk-core = { module = 'software.amazon.awssdk:sdk-core' }
+
+junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 
 # BOMs
 boms-opentelemetry = { module = 'io.opentelemetry:opentelemetry-bom', version.ref = 'managed-opentelemetry' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ managed-opentelemetry-alpha = '1.36.0-alpha'
 managed-opentelemetry-instrumentation = '1.33.1'
 managed-opentelemetry-instrumentation-alpha = '1.33.1-alpha'
 managed-opentelemetry-contrib-aws-xray = '1.34.0'
-managed-opentelemetry-contrib-aws-resources = '1.31.0-alpha'
+managed-opentelemetry-contrib-aws-resources = '1.34.0-alpha'
 managed-opentelemetry-gcp-trace = '0.27.0-alpha'
 managed-opentelemetry-semconv = '1.21.0-alpha'
 managed-protobuf = '0.9.4'
@@ -44,6 +44,7 @@ micronaut-gradle-plugin = "4.3.5"
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 
 managed-opentelemetry-contrib-aws-xray = { module = 'io.opentelemetry.contrib:opentelemetry-aws-xray', version.ref = 'managed-opentelemetry-contrib-aws-xray'}
+managed-opentelemetry-contrib-aws-xray-propagator = { module = 'io.opentelemetry.contrib:opentelemetry-aws-xray-propagator', version.ref = 'managed-opentelemetry-contrib-aws-resources' }
 managed-opentelemetry-contrib-aws-resources = { module = 'io.opentelemetry.contrib:opentelemetry-aws-resources', version.ref = 'managed-opentelemetry-contrib-aws-resources'}
 managed-opentelemetry-gcp-trace = { module = 'com.google.cloud.opentelemetry:exporter-auto', version.ref = 'managed-opentelemetry-gcp-trace'}
 
@@ -81,7 +82,6 @@ opentelemetry-sdk-testing = { module = 'io.opentelemetry:opentelemetry-sdk-testi
 opentelemetry-autoconfigure = { module = 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure' }
 opentelemetry-exporter-zipkin = { module = 'io.opentelemetry:opentelemetry-exporter-zipkin', version.ref = 'managed-opentelemetry' }
 opentelemetry-exporter-otlp = { module = 'io.opentelemetry:opentelemetry-exporter-otlp'}
-opentelemetry-extension-aws = { module = 'io.opentelemetry:opentelemetry-extension-aws' }
 opentelemetry-instrumentation-api = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api' }
 opentelemetry-instrumentation-grpc = { module = 'io.opentelemetry.instrumentation:opentelemetry-grpc-1.6'}
 opentelemetry-instrumentation-kafka-common = { module = 'io.opentelemetry.instrumentation:opentelemetry-kafka-clients-common'}

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include 'tracing-brave-http'
 
 include 'tests:kotlin-tests'
 include 'test-suite-java'
+include 'test-suite-opentelemetry-xray'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 

--- a/src/main/docs/guide/opentelemetry/awsResourceDetectors.adoc
+++ b/src/main/docs/guide/opentelemetry/awsResourceDetectors.adoc
@@ -2,7 +2,7 @@ https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr#usin
 
 To use AWS resource detectors include the following dependency:
 
-dependency:opentelemetry-sdk-extension-aws[groupId=io.opentelemetry]
+dependency:opentelemetry-aws-resources[groupId=io.opentelemetry.contrib]
 
 and provide a bean of type api:tracing.opentelemetry.ResourceProvider[]
 

--- a/src/main/docs/guide/opentelemetry/propagators.adoc
+++ b/src/main/docs/guide/opentelemetry/propagators.adoc
@@ -2,7 +2,7 @@ In your project you can specify propagators that you want to use. The default on
 
 To use https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader[AWS X-Ray] propagator inside your application you have to add next dependency in your project:
 
-dependency:opentelemetry-extension-aws[scope="implementation", groupId="io.opentelemetry"]
+dependency:opentelemetry-aws-xray-propagator[scope="implementation", groupId="io.opentelemetry.contrib"]
 
 And the "xray" has to be added inside configuration file.
 

--- a/test-suite-opentelemetry-xray/build.gradle.kts
+++ b/test-suite-opentelemetry-xray/build.gradle.kts
@@ -11,11 +11,12 @@ dependencies {
     testImplementation(projects.micronautTracingOpentelemetryHttp)
     testImplementation(libs.opentelemetry.exporter.otlp)
     testImplementation(libs.opentelemetry.aws.sdk)
-    testImplementation(libs.opentelemetry.extension.aws)
-
+    testImplementation(libs.managed.opentelemetry.contrib.aws.xray.propagator)
+    testImplementation(libs.managed.opentelemetry.contrib.aws.resources)
     testRuntimeOnly(libs.junit.engine)
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mnTest.micronaut.test.junit5)
+
 }
 tasks.withType<Test> {
     useJUnitPlatform()

--- a/test-suite-opentelemetry-xray/build.gradle.kts
+++ b/test-suite-opentelemetry-xray/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("java-library")
+}
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testRuntimeOnly(mnLogging.logback.classic)
+
+    testImplementation(projects.micronautTracingOpentelemetryHttp)
+    testImplementation(libs.opentelemetry.exporter.otlp)
+    testImplementation(libs.opentelemetry.aws.sdk)
+    testImplementation(libs.opentelemetry.extension.aws)
+
+    testRuntimeOnly(libs.junit.engine)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+}
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+java {
+    sourceCompatibility = JavaVersion.toVersion("17")
+    targetCompatibility = JavaVersion.toVersion("17")
+}

--- a/test-suite-opentelemetry-xray/src/test/java/io.micronaut.tracing.opentelementry.xray.test/OpenTelemetryExclusionsConfigurationTest.java
+++ b/test-suite-opentelemetry-xray/src/test/java/io.micronaut.tracing.opentelementry.xray.test/OpenTelemetryExclusionsConfigurationTest.java
@@ -1,0 +1,28 @@
+package io.micronaut.tracing.opentelementry.xray.test;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.micronaut.core.convert.format.MapFormat.MapTransformation.FLAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class OpenTelemetryExclusionsConfigurationTest {
+
+    @Test
+    void possibleToRetrieveConfiguration(@Property(name = "otel") @MapFormat(transformation = FLAT) Map<String, String> otelConfig) {
+        Map<String, String> otel = otelConfig.entrySet().stream().collect(Collectors.toMap(
+                e -> "otel." + e.getKey(),
+                Map.Entry::getValue
+        ));
+        assertEquals("/health", otel.get("otel.traces.exclusions"));
+        assertEquals("tracecontext, baggage, xray", otel.get("otel.traces.propagator"));
+        assertEquals("otlp", otel.get("otel.traces.exporter"));
+
+    }
+}

--- a/test-suite-opentelemetry-xray/src/test/resources/application.properties
+++ b/test-suite-opentelemetry-xray/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+otel.traces.exporter=otlp
+otel.traces.propagator=tracecontext, baggage, xray
+otel.traces.exclusions=/health


### PR DESCRIPTION
It replaces :

```
io.opentelemetry:opentelemetry-sdk-extension-aws
```

with:

```
io.opentelemetry.contrib:opentelemetry-aws-resources
```

and:

```
io.opentelemetry.contrib:opentelemetry-aws-xray-propagator
```

see:

https://github.com/open-telemetry/opentelemetry-java/pull/4945
https://github.com/open-telemetry/opentelemetry-java/issues/4831

it updates to https://github.com/open-telemetry/opentelemetry-java-contrib 1.34.0-Alpha

> Version 1.34.0 targets the OpenTelemetry SDK 1.34.0.

As we are in 1.36.0 I think this is the correct version to use for it.