### PR TITLE
fix: Remove core processor from the mn opentelemetry http library

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.tracing-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.tracing-module.gradle
@@ -12,10 +12,3 @@ dependencies {
     testImplementation mn.micronaut.inject.java
     testImplementation mn.micronaut.http.server.netty
 }
-
-tasks.withType(Test) {
-    testLogging {
-        showStandardStreams = true
-        exceptionFormat = 'full'
-    }
-}

--- a/test-suite-java/build.gradle
+++ b/test-suite-java/build.gradle
@@ -11,7 +11,7 @@ micronaut {
     enableNativeImage false
     processing {
         incremental(true)
-        annotations("helloworld.*")
+        annotations("opentelemetry.*")
     }
 }
 

--- a/tracing-annotation/build.gradle
+++ b/tracing-annotation/build.gradle
@@ -3,11 +3,5 @@ plugins {
 }
 
 dependencies {
-    api platform (libs.boms.opentelemetry)
-    api platform (libs.boms.opentelemetry.alpha)
-    api platform (libs.boms.opentelemetry.instrumentation)
-    api platform (libs.boms.opentelemetry.instrumentation.alpha)
-    api libs.opentelemetry.instrumentation.annotations
-
     implementation(mn.micronaut.core.processor)
 }

--- a/tracing-annotation/build.gradle
+++ b/tracing-annotation/build.gradle
@@ -3,5 +3,11 @@ plugins {
 }
 
 dependencies {
-    api mn.micronaut.core.processor
+    api platform (libs.boms.opentelemetry)
+    api platform (libs.boms.opentelemetry.alpha)
+    api platform (libs.boms.opentelemetry.instrumentation)
+    api platform (libs.boms.opentelemetry.instrumentation.alpha)
+    api libs.opentelemetry.instrumentation.annotations
+
+    implementation(mn.micronaut.core.processor)
 }

--- a/tracing-opentelemetry-annotation/build.gradle
+++ b/tracing-opentelemetry-annotation/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+    implementation(platform(libs.boms.opentelemetry.instrumentation))
+    implementation(libs.opentelemetry.instrumentation.annotations)
     implementation(mn.micronaut.core.processor)
     implementation(projects.micronautTracingAnnotation)
 

--- a/tracing-opentelemetry-annotation/build.gradle
+++ b/tracing-opentelemetry-annotation/build.gradle
@@ -5,18 +5,10 @@ plugins {
 }
 
 dependencies {
-    api platform (libs.boms.opentelemetry)
-    api platform (libs.boms.opentelemetry.alpha)
-    api platform (libs.boms.opentelemetry.instrumentation)
-    api platform (libs.boms.opentelemetry.instrumentation.alpha)
-    api mn.micronaut.core.processor
-    api projects.micronautTracingAnnotation
-    api libs.opentelemetry.instrumentation.annotations
+    implementation(mn.micronaut.core.processor)
+    implementation(projects.micronautTracingAnnotation)
 
     testImplementation mn.micronaut.inject.java.test
     testImplementation mn.micronaut.inject.groovy.test
-    if (!JavaVersion.current().isJava9Compatible()) {
-        testImplementation files(Jvm.current().toolsJar)
-    }
 }
 

--- a/tracing-opentelemetry-grpc/build.gradle
+++ b/tracing-opentelemetry-grpc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
     api mn.micronaut.core.processor
     compileOnly(mnGrpc.micronaut.grpc.client.runtime)
-    testImplementation(mnGrpc.micronaut.grpc.client.runtime)    
+    testImplementation(mnGrpc.micronaut.grpc.client.runtime)
     compileOnly(mnGrpc.micronaut.grpc.server.runtime)
     testImplementation(mnGrpc.micronaut.grpc.server.runtime)
     api projects.micronautTracingAnnotation
@@ -30,7 +30,6 @@ dependencies {
     testImplementation libs.grpc.protobuf
     testImplementation libs.grpc.stub
     testImplementation mnSerde.micronaut.serde.jackson
-
 }
 
 sourceSets {

--- a/tracing-opentelemetry-http/build.gradle
+++ b/tracing-opentelemetry-http/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     api platform (libs.boms.opentelemetry.alpha)
     api platform (libs.boms.opentelemetry.instrumentation)
     api platform (libs.boms.opentelemetry.instrumentation.alpha)
-    api mn.micronaut.core.processor
     api mn.micronaut.router
     api projects.micronautTracingAnnotation
     api projects.micronautTracingOpentelemetry
@@ -20,6 +19,7 @@ dependencies {
     compileOnly mn.kotlinx.coroutines.core
     compileOnly mn.kotlinx.coroutines.reactor
 
+    testImplementation(projects.micronautTracingOpentelemetryAnnotation) // For the mapper and transformer for the Groovy/Spock tests
     testImplementation mnReactor.micronaut.reactor
     testImplementation mnSerde.micronaut.serde.jackson
     testImplementation mnReactor.micronaut.reactor.http.client

--- a/tracing-opentelemetry-zipkin-exporter/build.gradle
+++ b/tracing-opentelemetry-zipkin-exporter/build.gradle
@@ -12,11 +12,3 @@ dependencies {
     testImplementation(projects.micronautTracingOpentelemetryHttp)
 }
 
-micronautBuild {
-    binaryCompatibility {
-        def dash = version.indexOf('-')
-        def v = dash > 0 ? version.substring(0, dash) : version
-        def (major, minor, patch) = v.split('[.]').collect { it.toInteger() }
-        enabled = major > 5 || (major == 5 && minor > 0) || (major == 5 && minor == 0 && patch > 2)
-    }
-}

--- a/tracing-opentelemetry/build.gradle
+++ b/tracing-opentelemetry/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     api mn.micronaut.core.processor
     api mn.micronaut.core.reactive
     api projects.micronautTracingAnnotation
-    api projects.micronautTracingOpentelemetryAnnotation
     api libs.opentelemetry.api
     api libs.opentelemetry.api.events
     api libs.opentelemetry.instrumentation.annotations
@@ -30,8 +29,7 @@ dependencies {
     compileOnly mn.kotlinx.coroutines.reactor
     compileOnly libs.managed.opentelemetry.contrib.aws.xray
 
-    testAnnotationProcessor projects.micronautTracingOpentelemetryAnnotation
-
+    testImplementation(projects.micronautTracingOpentelemetryAnnotation) // For the mapper and transformer for the Groovy/Spock tests
     testImplementation(libs.managed.opentelemetry.contrib.aws.resources)
 
     testImplementation mnReactor.micronaut.reactor


### PR DESCRIPTION
Closes #553

The Micronaut OpenTelemetry Http plugin was exposing an API dependency on the processor classes. This in turn pulled in 7Mb of unrequired dependencies.

This PR fixes this issue, and does a tiny bit of cleanup.

In general, this module seems to have an excessive use of `api` for dependencies. But I don't think we can do much more without causing downstream breakages.

I ran the guide mentioned in the issue, and then re-ran it with a snapshot version of this PR, the following Build Scans were the result:

`bookcatalog`
- before https://ge.micronaut.io/s/ofkuix744eine
- after https://ge.micronaut.io/s/fmdq4kubyy3g4

`bookinventory`
- before https://ge.micronaut.io/s/vokg7vtiyhztg
- after https://ge.micronaut.io/s/afzsqlypb2hhs

`bookrecommendation`
- before https://ge.micronaut.io/s/6ozkmgcfwtgb4
- after https://ge.micronaut.io/s/lhjxpoanbrvca