### PR TITLE
Fix: Ensure kotlin-stdlib is included for OpenTelemetry compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,7 @@ protoc-grpc = { module = 'io.grpc:protoc-gen-grpc-java', version.ref = 'grpc' }
 zipkin = { module = 'io.zipkin.zipkin2:zipkin', version.ref = 'managed-zipkin' }
 zipkin-reporter = { module = 'io.zipkin.reporter2:zipkin-reporter' }
 zipkin-reporter-brave = { module = 'io.zipkin.reporter2:zipkin-reporter-brave' }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api' }
 opentelemetry-api-events = { module = 'io.opentelemetry:opentelemetry-api-events', version.ref = 'managed-opentelemetry-api-events' }

--- a/tracing-opentelemetry-http/build.gradle
+++ b/tracing-opentelemetry-http/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     api libs.opentelemetry.instrumentation.api
     api libs.opentelemetry.instrumentation.api.semconv
     api libs.opentelemetry.instrumentation.semconv
+    api libs.kotlin.stdlib
 
     compileOnly mn.kotlinx.coroutines.core
     compileOnly mn.kotlinx.coroutines.reactor


### PR DESCRIPTION
issue #702
 
Without `kotlin-stdlib`, users encounter:
`java.lang.NoClassDefFoundError: kotlin/jvm/internal/Intrinsics`
This happens because OpenTelemetry’s `opentelemetry-exporter-sender-okhttp` depends on OkHttp, which **requires `kotlin-stdlib` at runtime

as a workaround we can add the following dependency manually :


```xml
 <dependency>
            <groupId>org.jetbrains.kotlin</groupId>
            <artifactId>kotlin-stdlib</artifactId>
            <version>1.9.25</version>
            <scope>runtime</scope>
        </dependency>

