### PR TITLE
OpenTelemetryBuilderCustomizer

### DIFF
--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -15,9 +15,6 @@
  */
 package io.micronaut.tracing.opentelemetry;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.env.Environment;
@@ -31,10 +28,13 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static io.micronaut.core.convert.format.MapFormat.MapTransformation.FLAT;
 
@@ -58,11 +58,12 @@ public class DefaultOpenTelemetryFactory {
      * The OpenTelemetry bean with default values.
      *
      * @param applicationConfiguration the {@link ApplicationConfiguration}
-     * @param otelConfig the configuration values for the opentelemetry autoconfigure
-     * @param idGenerator the {@link IdGenerator}
-     * @param spanProcessor the {@link SpanProcessor}
-     * @param resourceProvider Resource Provider
-     *
+     * @param otelConfig               the configuration values for the opentelemetry autoconfigure
+     * @param idGenerator              the {@link IdGenerator}
+     * @param spanProcessor            the {@link SpanProcessor}
+     * @param resourceProvider         Resource Provider
+     * @param sampler                  sampler
+     * @param builderCustomizers       optional builder customizer beans
      * @return the OpenTelemetry bean with default values
      */
     @Singleton
@@ -71,7 +72,8 @@ public class DefaultOpenTelemetryFactory {
                                                  @Nullable IdGenerator idGenerator,
                                                  @Nullable SpanProcessor spanProcessor,
                                                  @Nullable ResourceProvider resourceProvider,
-                                                 @Nullable Sampler sampler) {
+                                                 @Nullable Sampler sampler,
+                                                 Collection<OpenTelemetryBuilderCustomizer> builderCustomizers) {
 
         Map<String, String> otel = otelConfig.entrySet().stream().collect(Collectors.toMap(
             e -> "otel." + e.getKey(),
@@ -107,6 +109,10 @@ public class DefaultOpenTelemetryFactory {
                     return tracerProviderBuilder;
                 }
             );
+
+        for (OpenTelemetryBuilderCustomizer customizer : builderCustomizers) {
+            customizer.configure(sdk);
+        }
 
         return sdk.build().getOpenTelemetrySdk();
     }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizer.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry;
+
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+
+/**
+ * Allows external configuration of the AutoConfiguredOpenTelemetrySdkBuilder
+ * created in DefaultOpenTelemetryFactory.
+ */
+public interface OpenTelemetryBuilderCustomizer {
+
+    /**
+     * Apply customizations.
+     *
+     * @param builder the builder
+     */
+    void configure(AutoConfiguredOpenTelemetrySdkBuilder builder);
+}


### PR DESCRIPTION
Adds the `OpenTelemetryBuilderCustomizer` interface and updates `DefaultOpenTelemetryFactory` to find implementations when creating the OpenTelemetry bean, to allow external builder configuration