### PR TITLE
define depency to opentelemetry-instrumentation-api-incubator

### DIFF
--- a/tracing-opentelemetry/build.gradle
+++ b/tracing-opentelemetry/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     api libs.opentelemetry.api.incubator
     api libs.opentelemetry.instrumentation.annotations
     api libs.opentelemetry.instrumentation.api
+    api(libs.opentelemetry.instrumentation.api.incubator)
     api libs.opentelemetry.autoconfigure
 
     implementation(platform(libs.micronaut.aws))


### PR DESCRIPTION
see: https://github.com/micronaut-projects/micronaut-azure/pull/857
`NewSpanOpenTelemetryTraceInterceptor` uses `io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod`.That class comes from: `io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.16.0-alpha`

 It does not define a `@Requires` to that class.

However, that dependency is resolved right now as a transitive dependency of the `opentelemetry-aws-sdk` compileOnly dependency:

```
   +--- io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2:2.16.0-alpha (c)
|    \--- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.16.0-alpha (c)
```

I see two solutions:

- We annotate `NewSpanOpenTelemetryTraceInterceptor` with `@Requires(ClassAndMethod.class)` 

- We define the instrumentation.api.incubator dependency explicitly.

This PR adds the dependency.