### PR TITLE
Fixes #837 - replace deprecated mainClassName with application.mainClass

### DIFF
--- a/test-suite-java/build.gradle
+++ b/test-suite-java/build.gradle
@@ -3,7 +3,9 @@ plugins {
     id 'io.micronaut.build.internal.tracing-native-tests'
 }
 
-mainClassName = "micronaut.example.Application"
+application {
+    mainClass = "micronaut.example.Application"
+}
 micronaut {
     version libs.versions.micronaut.platform.get()
     coreVersion.set(libs.versions.micronaut.asProvider().get())


### PR DESCRIPTION
Fixes #837 - replace deprecated mainClassName with application.mainClass