### PR TITLE
Batch safe dependency upgrades from Renovate batch

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ managed-opentracing = '0.33.0'
 managed-opentracing-grpc = '0.2.3'
 managed-brave-opentracing = '1.0.1'
 javax-annotation = '1.3.2'
-grpc = '1.75.0'
+grpc = '1.80.0'
 protobuf = '3.25.8'
 gson = '2.13.2'
 


### PR DESCRIPTION
This realigns the combined dependency-upgrade PR for the Renovate follow-up issue with the current 8.0.x branch.

Included Renovate candidate still not present on 8.0.x:
- #834: update grpc-java from 1.75.0 to 1.80.0

Tracked candidates already represented on current 8.0.x or closed by Renovate after validation:
- #848 and #847: opentelemetry-semconv 1.40.0 is already present on 8.0.x
- #843: protobuf Gradle plugin 0.10.0 is already present on 8.0.x
- #835: opentelemetry-java 1.61.0 was already merged into 8.0.x before this realignment
- #833 and #831: opentelemetry-instrumentation-bom 2.27.0 is already present on 8.0.x
- #830: opentelemetry-aws-xray 1.55.0 is already present on 8.0.x
- #846 and #786: these only update OSS Index exclusion coordinates for lz4-java 1.8.1 and okio 2.10.0; current 8.0.x already carries those exclusions

Safety check:
- Confirmed the tracked Renovate proposals are non-major updates.
- The branch now avoids stale reversions of newer base changes, including Micronaut 5.0.0-M24, OpenTelemetry 1.61.0, Kafka 6.0.0-M2, and the R2DBC module additions.

Verification:
- ./gradlew :micronaut-tracing-opentelemetry-grpc:test :micronaut-tracing-bom:checkBom --no-daemon

Resolves #853
