### PR TITLE
Fix mangled span names for Kotlin Result methods

### DIFF
--- a/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
+++ b/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
@@ -14,6 +14,7 @@ class ResultSpanNameSpec {
         val defaultMethod = methodNames.single { it.startsWith("defaultSpan-") }
         val customMethod = customMethodNames.single { it.startsWith("customSpan-") }
         val backtickMethod = methodNames.single { it == "hyphen-name" }
+        val longBacktickMethod = methodNames.single { it == "long-hyphenated-backtick-name" }
 
         Assertions.assertNotEquals("defaultSpan", defaultMethod)
         Assertions.assertNotEquals("customSpan", customMethod)
@@ -29,6 +30,7 @@ class ResultSpanNameSpec {
         Assertions.assertEquals("defaultSpan-hash\$other", MethodNameFormatter.format("defaultSpan-hash\$other"))
         Assertions.assertEquals("plainMethod", MethodNameFormatter.format("plainMethod"))
         Assertions.assertEquals("hyphen-name", MethodNameFormatter.format(backtickMethod))
+        Assertions.assertEquals("long-hyphenated-backtick-name", MethodNameFormatter.format(longBacktickMethod))
     }
 }
 
@@ -38,6 +40,8 @@ open class ResultSpanService {
     open fun defaultSpan(): Result<String> = Result.success("hello")
 
     open fun `hyphen-name`(): String = "hello"
+
+    open fun `long-hyphenated-backtick-name`(): String = "hello"
 }
 
 open class CustomResultSpanService {

--- a/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
+++ b/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
@@ -10,14 +10,16 @@ class ResultSpanNameSpec {
     @Test
     fun `formatter strips Kotlin Result mangling from method names`() {
         val methodNames = ResultSpanService::class.java.declaredMethods.map { it.name }.toSet()
-        val defaultMethod = methodNames.first { it.startsWith("defaultSpan") }
-        val customMethod = methodNames.first { it.startsWith("customSpan") }
+        val defaultMethod = methodNames.single { it.startsWith("defaultSpan-") }
+        val customMethod = methodNames.single { it.startsWith("customSpan-") }
 
         Assertions.assertNotEquals("defaultSpan", defaultMethod)
         Assertions.assertNotEquals("customSpan", customMethod)
         Assertions.assertEquals("defaultSpan", MethodNameFormatter.format(defaultMethod))
         Assertions.assertEquals("customSpan", MethodNameFormatter.format(customMethod))
         Assertions.assertEquals("customSpan#helloworld", MethodNameFormatter.format(customMethod) + "#helloworld")
+        Assertions.assertEquals("defaultSpan", MethodNameFormatter.format("defaultSpan-longerHash"))
+        Assertions.assertEquals("defaultSpan", MethodNameFormatter.format("defaultSpan-longerHash\$default"))
         Assertions.assertEquals("plainMethod", MethodNameFormatter.format("plainMethod"))
     }
 }

--- a/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
+++ b/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
@@ -1,0 +1,32 @@
+package tracing
+
+import io.micronaut.tracing.annotation.NewSpan
+import io.micronaut.tracing.util.MethodNameFormatter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ResultSpanNameSpec {
+
+    @Test
+    fun `formatter strips Kotlin Result mangling from method names`() {
+        val methodNames = ResultSpanService::class.java.declaredMethods.map { it.name }.toSet()
+        val defaultMethod = methodNames.first { it.startsWith("defaultSpan") }
+        val customMethod = methodNames.first { it.startsWith("customSpan") }
+
+        Assertions.assertNotEquals("defaultSpan", defaultMethod)
+        Assertions.assertNotEquals("customSpan", customMethod)
+        Assertions.assertEquals("defaultSpan", MethodNameFormatter.format(defaultMethod))
+        Assertions.assertEquals("customSpan", MethodNameFormatter.format(customMethod))
+        Assertions.assertEquals("customSpan#helloworld", MethodNameFormatter.format(customMethod) + "#helloworld")
+        Assertions.assertEquals("plainMethod", MethodNameFormatter.format("plainMethod"))
+    }
+}
+
+open class ResultSpanService {
+
+    @NewSpan
+    open fun defaultSpan(): Result<String> = Result.success("hello")
+
+    @NewSpan("helloworld")
+    open fun customSpan(): Result<String> = Result.success("hello")
+}

--- a/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
+++ b/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
@@ -10,8 +10,10 @@ class ResultSpanNameSpec {
     @Test
     fun `formatter strips Kotlin Result mangling from method names`() {
         val methodNames = ResultSpanService::class.java.declaredMethods.map { it.name }.toSet()
+        val customMethodNames = CustomResultSpanService::class.java.declaredMethods.map { it.name }.toSet()
         val defaultMethod = methodNames.single { it.startsWith("defaultSpan-") }
-        val customMethod = methodNames.single { it.startsWith("customSpan-") }
+        val customMethod = customMethodNames.single { it.startsWith("customSpan-") }
+        val backtickMethod = methodNames.single { it == "hyphen-name" }
 
         Assertions.assertNotEquals("defaultSpan", defaultMethod)
         Assertions.assertNotEquals("customSpan", customMethod)
@@ -26,6 +28,7 @@ class ResultSpanNameSpec {
         Assertions.assertEquals("defaultSpan-short", MethodNameFormatter.format("defaultSpan-short"))
         Assertions.assertEquals("defaultSpan-hash\$other", MethodNameFormatter.format("defaultSpan-hash\$other"))
         Assertions.assertEquals("plainMethod", MethodNameFormatter.format("plainMethod"))
+        Assertions.assertEquals("hyphen-name", MethodNameFormatter.format(backtickMethod))
     }
 }
 
@@ -33,6 +36,11 @@ open class ResultSpanService {
 
     @NewSpan
     open fun defaultSpan(): Result<String> = Result.success("hello")
+
+    open fun `hyphen-name`(): String = "hello"
+}
+
+open class CustomResultSpanService {
 
     @NewSpan("helloworld")
     open fun customSpan(): Result<String> = Result.success("hello")

--- a/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
+++ b/tests/kotlin-tests/src/test/kotlin/tracing/ResultSpanNameSpec.kt
@@ -20,6 +20,11 @@ class ResultSpanNameSpec {
         Assertions.assertEquals("customSpan#helloworld", MethodNameFormatter.format(customMethod) + "#helloworld")
         Assertions.assertEquals("defaultSpan", MethodNameFormatter.format("defaultSpan-longerHash"))
         Assertions.assertEquals("defaultSpan", MethodNameFormatter.format("defaultSpan-longerHash\$default"))
+        Assertions.assertEquals("defaultSpan", MethodNameFormatter.format("defaultSpan-longer-Hash\$default"))
+        Assertions.assertEquals("defaultSpan-", MethodNameFormatter.format("defaultSpan-"))
+        Assertions.assertEquals("defaultSpan-\$default", MethodNameFormatter.format("defaultSpan-\$default"))
+        Assertions.assertEquals("defaultSpan-short", MethodNameFormatter.format("defaultSpan-short"))
+        Assertions.assertEquals("defaultSpan-hash\$other", MethodNameFormatter.format("defaultSpan-hash\$other"))
         Assertions.assertEquals("plainMethod", MethodNameFormatter.format("plainMethod"))
     }
 }

--- a/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
+++ b/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.util;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Formats method names for tracing output.
+ */
+@Internal
+public final class MethodNameFormatter {
+
+    private static final Pattern KOTLIN_INLINE_CLASS_MANGLING = Pattern.compile("^(?<name>.+)-(?:\\w{7})(?:\\$default)?$");
+
+    private MethodNameFormatter() {
+    }
+
+    /**
+     * Normalize Kotlin inline class mangled method names to the source method name.
+     *
+     * @param methodName The raw method name
+     * @return The formatted method name
+     */
+    public static String format(String methodName) {
+        Matcher matcher = KOTLIN_INLINE_CLASS_MANGLING.matcher(methodName);
+        if (matcher.matches()) {
+            return matcher.group("name");
+        }
+        return methodName;
+    }
+}

--- a/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
+++ b/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 @Internal
 public final class MethodNameFormatter {
 
-    private static final Pattern KOTLIN_INLINE_CLASS_MANGLING = Pattern.compile("^(?<name>.+)-(?:\\w{7})(?:\\$default)?$");
+    private static final Pattern KOTLIN_INLINE_CLASS_MANGLING = Pattern.compile("^(?<name>.+)-[^$]+(?:\\$default)?$");
 
     private MethodNameFormatter() {
     }

--- a/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
+++ b/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
@@ -17,16 +17,14 @@ package io.micronaut.tracing.util;
 
 import io.micronaut.core.annotation.Internal;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Formats method names for tracing output.
  */
 @Internal
 public final class MethodNameFormatter {
 
-    private static final Pattern KOTLIN_INLINE_CLASS_MANGLING = Pattern.compile("^(?<name>.+)-[^$]+(?:\\$default)?$");
+    private static final String DEFAULT_METHOD_SUFFIX = "$default";
+    private static final int MINIMUM_MANGLING_SUFFIX_LENGTH = 7;
 
     private MethodNameFormatter() {
     }
@@ -38,10 +36,34 @@ public final class MethodNameFormatter {
      * @return The formatted method name
      */
     public static String format(String methodName) {
-        Matcher matcher = KOTLIN_INLINE_CLASS_MANGLING.matcher(methodName);
-        if (matcher.matches()) {
-            return matcher.group("name");
+        String name = methodName.endsWith(DEFAULT_METHOD_SUFFIX)
+            ? methodName.substring(0, methodName.length() - DEFAULT_METHOD_SUFFIX.length())
+            : methodName;
+        int manglingSeparator = name.indexOf('-');
+        if (manglingSeparator > 0 && isKotlinManglingSuffix(name, manglingSeparator + 1)) {
+            return name.substring(0, manglingSeparator);
         }
         return methodName;
+    }
+
+    private static boolean isKotlinManglingSuffix(String name, int suffixStart) {
+        if (name.length() - suffixStart < MINIMUM_MANGLING_SUFFIX_LENGTH) {
+            return false;
+        }
+        for (int i = suffixStart; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (!isUrlSafeBase64Character(c)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isUrlSafeBase64Character(char c) {
+        return c >= 'A' && c <= 'Z'
+            || c >= 'a' && c <= 'z'
+            || c >= '0' && c <= '9'
+            || c == '_'
+            || c == '-';
     }
 }

--- a/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
+++ b/tracing-annotation/src/main/java/io/micronaut/tracing/util/MethodNameFormatter.java
@@ -50,13 +50,17 @@ public final class MethodNameFormatter {
         if (name.length() - suffixStart < MINIMUM_MANGLING_SUFFIX_LENGTH) {
             return false;
         }
+        boolean containsHashMarker = false;
         for (int i = suffixStart; i < name.length(); i++) {
             char c = name.charAt(i);
             if (!isUrlSafeBase64Character(c)) {
                 return false;
             }
+            if (c != '-' && (c < 'a' || c > 'z')) {
+                containsHashMarker = true;
+            }
         }
-        return true;
+        return containsHashMarker;
     }
 
     private static boolean isUrlSafeBase64Character(char c) {

--- a/tracing-annotation/src/test/groovy/io/micronaut/tracing/util/MethodNameFormatterSpec.groovy
+++ b/tracing-annotation/src/test/groovy/io/micronaut/tracing/util/MethodNameFormatterSpec.groovy
@@ -22,6 +22,7 @@ class MethodNameFormatterSpec extends Specification {
         'defaultSpan-'                     | 'defaultSpan-'
         'defaultSpan-$default'             | 'defaultSpan-$default'
         '-leadingSeparator'                | '-leadingSeparator'
+        'hyphen-name'                      | 'hyphen-name'
         'plainMethod'                      | 'plainMethod'
     }
 }

--- a/tracing-annotation/src/test/groovy/io/micronaut/tracing/util/MethodNameFormatterSpec.groovy
+++ b/tracing-annotation/src/test/groovy/io/micronaut/tracing/util/MethodNameFormatterSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.tracing.util
+
+import spock.lang.Specification
+
+class MethodNameFormatterSpec extends Specification {
+
+    void 'formats Kotlin mangled method names'() {
+        expect:
+        MethodNameFormatter.format(methodName) == formattedName
+
+        where:
+        methodName                         | formattedName
+        'defaultSpan-Aa0_--Z'              | 'defaultSpan'
+        'defaultSpan-longerHash'           | 'defaultSpan'
+        'defaultSpan-longerHash$default'   | 'defaultSpan'
+        'defaultSpan-short'                | 'defaultSpan-short'
+        'defaultSpan-hash$other'           | 'defaultSpan-hash$other'
+        'defaultSpan-hash.with.dot'        | 'defaultSpan-hash.with.dot'
+        'defaultSpan-hash{invalid'         | 'defaultSpan-hash{invalid'
+        'defaultSpan-hash:invalid'         | 'defaultSpan-hash:invalid'
+        'defaultSpan-longer-Hash$default'  | 'defaultSpan'
+        'defaultSpan-'                     | 'defaultSpan-'
+        'defaultSpan-$default'             | 'defaultSpan-$default'
+        '-leadingSeparator'                | '-leadingSeparator'
+        'plainMethod'                      | 'plainMethod'
+    }
+}

--- a/tracing-annotation/src/test/groovy/io/micronaut/tracing/util/MethodNameFormatterSpec.groovy
+++ b/tracing-annotation/src/test/groovy/io/micronaut/tracing/util/MethodNameFormatterSpec.groovy
@@ -23,6 +23,7 @@ class MethodNameFormatterSpec extends Specification {
         'defaultSpan-$default'             | 'defaultSpan-$default'
         '-leadingSeparator'                | '-leadingSeparator'
         'hyphen-name'                      | 'hyphen-name'
+        'long-hyphenated-backtick-name'    | 'long-hyphenated-backtick-name'
         'plainMethod'                      | 'plainMethod'
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/interceptor/AbstractOpenTelemetryTraceInterceptor.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/interceptor/AbstractOpenTelemetryTraceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/interceptor/NewSpanOpenTelemetryTraceInterceptor.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/interceptor/NewSpanOpenTelemetryTraceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.tracing.annotation.NewSpan;
 import io.micronaut.tracing.opentelemetry.OpenTelemetryPropagationContext;
+import io.micronaut.tracing.util.MethodNameFormatter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
@@ -77,7 +78,7 @@ public final class NewSpanOpenTelemetryTraceInterceptor extends AbstractOpenTele
         String operationName = newSpan.stringValue().orElse("");
         ClassAndMethod classAndMethod;
 
-        ClassAndMethod basicClassAndMethod = ClassAndMethod.create(context.getDeclaringType(), context.getMethodName());
+        ClassAndMethod basicClassAndMethod = ClassAndMethod.create(context.getDeclaringType(), MethodNameFormatter.format(context.getMethodName()));
         if (StringUtils.isNotEmpty(operationName)) {
             classAndMethod = ClassAndMethod.create(basicClassAndMethod.declaringClass(), basicClassAndMethod.methodName() + '#' + operationName);
         } else {

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/interceptor/NewSpanOpenTelemetryTraceInterceptorSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/interceptor/NewSpanOpenTelemetryTraceInterceptorSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.tracing.opentelemetry.interceptor
+
+import io.micronaut.aop.MethodInvocationContext
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.ReturnType
+import io.micronaut.tracing.annotation.NewSpan
+import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import spock.lang.Specification
+
+class NewSpanOpenTelemetryTraceInterceptorSpec extends Specification {
+
+    void 'span name uses source method name for Kotlin Result return type'() {
+        given:
+        ClassAndMethod classAndMethod = null
+        Instrumenter<ClassAndMethod, Object> instrumenter = Stub() {
+            shouldStart(_, _) >> { Context context, ClassAndMethod method ->
+                classAndMethod = method
+                true
+            }
+            start(_, _) >> { Context context, ClassAndMethod method -> context }
+        }
+        def interceptor = new NewSpanOpenTelemetryTraceInterceptor(instrumenter, ConversionService.SHARED)
+        def context = Stub(MethodInvocationContext) {
+            getAnnotation(NewSpan) >> AnnotationValue.builder(NewSpan).build()
+            getDeclaringType() >> KotlinResultService
+            getMethodName() >> 'hello-d1pmJ48'
+            getReturnType() >> ReturnType.of(String)
+            getArguments() >> Argument.ZERO_ARGUMENTS
+            getParameterValues() >> ([] as Object[])
+            proceed() >> 'hello'
+        }
+
+        expect:
+        interceptor.intercept(context) == 'hello'
+        classAndMethod.methodName() == 'hello'
+    }
+
+    void 'custom span name does not include Kotlin mangled method name for Result return type'() {
+        given:
+        ClassAndMethod classAndMethod = null
+        Instrumenter<ClassAndMethod, Object> instrumenter = Stub() {
+            shouldStart(_, _) >> { Context context, ClassAndMethod method ->
+                classAndMethod = method
+                true
+            }
+            start(_, _) >> { Context context, ClassAndMethod method -> context }
+        }
+        def interceptor = new NewSpanOpenTelemetryTraceInterceptor(instrumenter, ConversionService.SHARED)
+        def context = Stub(MethodInvocationContext) {
+            getAnnotation(NewSpan) >> AnnotationValue.builder(NewSpan).value('helloworld').build()
+            getDeclaringType() >> KotlinResultService
+            getMethodName() >> 'hello-d1pmJ48'
+            getReturnType() >> ReturnType.of(String)
+            getArguments() >> Argument.ZERO_ARGUMENTS
+            getParameterValues() >> ([] as Object[])
+            proceed() >> 'hello'
+        }
+
+        expect:
+        interceptor.intercept(context) == 'hello'
+        classAndMethod.methodName() == 'hello#helloworld'
+    }
+
+    static class KotlinResultService {
+    }
+}

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/interceptor/AbstractTraceInterceptor.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/interceptor/AbstractTraceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.tracing.annotation.SpanTag;
+import io.micronaut.tracing.util.MethodNameFormatter;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 
@@ -71,7 +72,7 @@ public abstract sealed class AbstractTraceInterceptor implements MethodIntercept
     protected final void populateTags(MethodInvocationContext<Object, Object> context,
                                       Span span) {
         span.setTag(CLASS_TAG, context.getDeclaringType().getSimpleName());
-        span.setTag(METHOD_TAG, context.getMethodName());
+        span.setTag(METHOD_TAG, MethodNameFormatter.format(context.getMethodName()));
         tagArguments(span, context);
     }
 

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/interceptor/NewSpanTraceInterceptor.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/interceptor/NewSpanTraceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.tracing.annotation.NewSpan;
 import io.micronaut.tracing.opentracing.OpenTracingPropagationContext;
+import io.micronaut.tracing.util.MethodNameFormatter;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import jakarta.inject.Singleton;
@@ -64,7 +65,7 @@ public final class NewSpanTraceInterceptor extends AbstractTraceInterceptor {
         if (!isNew) {
             return context.proceed();
         }
-        String operationName = newSpan.stringValue().orElse(context.getDeclaringType().getSimpleName() + "." + context.getMethodName());
+        String operationName = newSpan.stringValue().orElse(context.getDeclaringType().getSimpleName() + "." + MethodNameFormatter.format(context.getMethodName()));
 
         Tracer.SpanBuilder builder = tracer.buildSpan(operationName);
         if (currentSpan != null) {

--- a/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/interceptor/NewSpanTraceInterceptorSpec.groovy
+++ b/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/interceptor/NewSpanTraceInterceptorSpec.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.tracing.opentracing.interceptor
+
+import io.micronaut.aop.MethodInvocationContext
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.ReturnType
+import io.micronaut.tracing.annotation.NewSpan
+import io.opentracing.Scope
+import io.opentracing.Span
+import io.opentracing.Tracer
+import spock.lang.Specification
+
+class NewSpanTraceInterceptorSpec extends Specification {
+
+    void 'span name and method tag use source method name for Kotlin Result return type'() {
+        given:
+        String operationName = null
+        Span span = Mock()
+        Scope scope = Mock()
+        Tracer.SpanBuilder spanBuilder = Stub() {
+            start() >> span
+        }
+        Tracer tracer = Stub() {
+            activeSpan() >> null
+            buildSpan(_) >> { String name ->
+                operationName = name
+                spanBuilder
+            }
+            activateSpan(span) >> scope
+        }
+        def interceptor = new NewSpanTraceInterceptor(tracer, ConversionService.SHARED)
+        def context = Stub(MethodInvocationContext) {
+            getAnnotation(NewSpan) >> AnnotationValue.builder(NewSpan).build()
+            getDeclaringType() >> KotlinResultService
+            getMethodName() >> 'hello-d1pmJ48'
+            getReturnType() >> ReturnType.of(String)
+            getArguments() >> Argument.ZERO_ARGUMENTS
+            getParameterValues() >> ([] as Object[])
+            proceed() >> 'hello'
+        }
+
+        when:
+        def result = interceptor.intercept(context)
+
+        then:
+        result == 'hello'
+        operationName == 'KotlinResultService.hello'
+        2 * span.setTag(AbstractTraceInterceptor.CLASS_TAG, 'KotlinResultService') >> span
+        2 * span.setTag(AbstractTraceInterceptor.METHOD_TAG, 'hello') >> span
+        1 * span.finish()
+        1 * scope.close()
+    }
+
+    static class KotlinResultService {
+    }
+}


### PR DESCRIPTION
## Summary
- normalize Kotlin inline-class/Result mangled method names before building tracing span names
- apply the normalization to both OpenTelemetry and OpenTracing interceptors
- add a Kotlin regression test that uses compiled Result-returning method names

Resolves #573