### PR TITLE
Defer JDBC OpenTelemetry initialization during startup

### DIFF
--- a/tracing-opentelemetry-jdbc/build.gradle
+++ b/tracing-opentelemetry-jdbc/build.gradle
@@ -12,13 +12,8 @@ dependencies {
     api libs.opentelemetry.instrumentation.semconv
     api libs.opentelemetry.instrumentation.jdbc
     implementation mnSql.micronaut.jdbc
-    implementation mnData.micronaut.data.jdbc
-
-
-    testAnnotationProcessor mnData.micronaut.data.processor
 
     testImplementation mnSerde.micronaut.serde.jackson
-    testImplementation mnData.micronaut.data.jdbc
     testImplementation mnSql.micronaut.jdbc.hikari
 
     testImplementation libs.opentelemetry.sdk

--- a/tracing-opentelemetry-jdbc/src/main/java/io/micronaut/tracing/opentelemetry/instrument/jdbc/DataSourceBeanCreatedEventListener.java
+++ b/tracing-opentelemetry-jdbc/src/main/java/io/micronaut/tracing/opentelemetry/instrument/jdbc/DataSourceBeanCreatedEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.micronaut.tracing.opentelemetry.instrument.jdbc;
 
+import io.micronaut.context.BeanProvider;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.annotation.Internal;
@@ -26,17 +27,17 @@ import javax.sql.DataSource;
 
 /**
  * Wraps the DataSource so OTEL can gather data for spans.
- * @param jdbcTelemetryConfiguration the otel JDBC configuration.
+ * @param jdbcTelemetryConfiguration the otel JDBC configuration provider.
  */
 @Singleton
 @Internal
 record DataSourceBeanCreatedEventListener(
-    JdbcTelemetryConfiguration jdbcTelemetryConfiguration)
+    BeanProvider<JdbcTelemetryConfiguration> jdbcTelemetryConfiguration)
     implements BeanCreatedEventListener<DataSource>, Ordered {
 
     @Override
     public DataSource onCreated(@NonNull BeanCreatedEvent<DataSource> event) {
-        return jdbcTelemetryConfiguration.builder
+        return jdbcTelemetryConfiguration.get().builder
             .build().wrap(event.getBean());
     }
 

--- a/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/jdbc/JdbcTelemetryBeanCreationSpec.groovy
+++ b/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/jdbc/JdbcTelemetryBeanCreationSpec.groovy
@@ -1,6 +1,9 @@
 package io.micronaut.tracing.opentelemetry.instrument.jdbc
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.context.event.StartupEvent
+import io.micronaut.core.type.Argument
 import spock.lang.Specification
 
 class JdbcTelemetryBeanCreationSpec extends Specification {
@@ -16,6 +19,39 @@ class JdbcTelemetryBeanCreationSpec extends Specification {
         then:
         dataSourceBeanCreatedEventListener
         jdbcTelemetryConfiguration
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test jdbc telemetry starts in k8s cloud environment"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'datasources.default.dialect': 'H2',
+                'micronaut.application.name': 'otel-test',
+                'datasources.default.url': 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE',
+                'datasources.default.username': 'sa',
+                'datasources.default.driver-class-name': 'org.h2.Driver'
+        ], "k8s", "cloud")
+
+        expect:
+        ctx.getBean(DataSourceBeanCreatedEventListener)
+        ctx.getBean(JdbcTelemetryConfiguration)
+        ctx.getBean(Argument.of(ApplicationEventPublisher, StartupEvent))
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test jdbc telemetry listener does not eagerly create open telemetry during startup"() {
+        when:
+        ApplicationContext ctx = ApplicationContext.run([
+                "micronaut.eager-init.singletons": "true",
+                "test.open-telemetry.requires-startup-event-publisher": "true",
+        ])
+
+        then:
+        ctx.containsBean(DataSourceBeanCreatedEventListener)
 
         cleanup:
         ctx.close()
@@ -39,4 +75,3 @@ class JdbcTelemetryBeanCreationSpec extends Specification {
         ctx.close()
     }
 }
-

--- a/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/jdbc/JdbcTelemetryBeanCreationSpec.groovy
+++ b/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/jdbc/JdbcTelemetryBeanCreationSpec.groovy
@@ -4,7 +4,10 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.event.ApplicationEventPublisher
 import io.micronaut.context.event.StartupEvent
 import io.micronaut.core.type.Argument
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import spock.lang.Specification
+
+import javax.sql.DataSource
 
 class JdbcTelemetryBeanCreationSpec extends Specification {
 
@@ -57,6 +60,31 @@ class JdbcTelemetryBeanCreationSpec extends Specification {
         ctx.close()
     }
 
+    void "test startup event dependent open telemetry wraps datasource during eager startup"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'datasources.default.dialect': 'H2',
+                'micronaut.application.name': 'otel-test',
+                'datasources.default.url': 'jdbc:h2:mem:startupDependentDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE',
+                'datasources.default.username': 'sa',
+                'datasources.default.driver-class-name': 'org.h2.Driver',
+                'micronaut.eager-init.singletons': 'true',
+                'test.open-telemetry.requires-startup-event-publisher': 'true',
+        ])
+
+        when:
+        executeSql(ctx, "CREATE TABLE foo (id INT PRIMARY KEY, name VARCHAR(255))")
+
+        then:
+        ctx.getBean(DataSourceBeanCreatedEventListener)
+        ctx.getBean(JdbcTelemetryConfiguration)
+        ctx.getBean(DataSource)
+        ctx.getBean(InMemorySpanExporter).finishedSpanItems.size() == 1
+
+        cleanup:
+        ctx.close()
+    }
+
     void "test jdbc disabled with property"() {
         given:
         ApplicationContext ctx = ApplicationContext.run([
@@ -73,5 +101,13 @@ class JdbcTelemetryBeanCreationSpec extends Specification {
 
         cleanup:
         ctx.close()
+    }
+
+    private static void executeSql(ApplicationContext ctx, String sql) {
+        ctx.getBean(DataSource).connection.withCloseable { connection ->
+            connection.createStatement().withCloseable { statement ->
+                statement.execute(sql)
+            }
+        }
     }
 }

--- a/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/jdbc/JdbcTelemetrySpanSpec.groovy
+++ b/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/jdbc/JdbcTelemetrySpanSpec.groovy
@@ -5,6 +5,8 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import spock.lang.Specification
 
+import javax.sql.DataSource
+
 class JdbcTelemetrySpanSpec  extends Specification {
 
     void "test jdbc telemetry enabled by default"() {
@@ -12,7 +14,6 @@ class JdbcTelemetrySpanSpec  extends Specification {
         ApplicationContext ctx = ApplicationContext.run([
                 'datasources.default.dialect': 'H2',
                 'micronaut.application.name': 'otel-test',
-                'datasources.default.schema-generate': 'CREATE_DROP',
                 'datasources.default.url': 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE',
                 'datasources.default.username': 'sa',
                 'datasources.default.driver-class-name': 'org.h2.Driver'
@@ -22,6 +23,8 @@ class JdbcTelemetrySpanSpec  extends Specification {
         def dataSourceBeanCreatedEventListener= ctx.getBean(DataSourceBeanCreatedEventListener)
         def jdbcTelemetryConfiguration = ctx.getBean(JdbcTelemetryConfiguration)
         def inMemorySpanExporter = ctx.getBean(InMemorySpanExporter)
+        executeSql(ctx, "CREATE TABLE foo (id INT PRIMARY KEY, name VARCHAR(255))")
+        executeSql(ctx, "DROP TABLE foo")
 
         then:
         dataSourceBeanCreatedEventListener
@@ -31,8 +34,8 @@ class JdbcTelemetrySpanSpec  extends Specification {
 
         finishedSpanItems.size() == 2
 
-        finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("db.statement")).contains("DROP TABLE `foo`"))
-        finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("db.statement")).contains("CREATE TABLE `foo`"))
+        finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("db.statement")).contains("DROP TABLE foo"))
+        finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey("db.statement")).contains("CREATE TABLE foo"))
 
         cleanup:
         ctx.close()
@@ -43,7 +46,6 @@ class JdbcTelemetrySpanSpec  extends Specification {
         ApplicationContext ctx = ApplicationContext.run([
             'datasources.default.dialect': 'H2',
             'micronaut.application.name': 'otel-test',
-            'datasources.default.schema-generate': 'CREATE_DROP',
             'datasources.default.url': 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE',
             'datasources.default.username': 'sa',
             'datasources.default.driver-class-name': 'org.h2.Driver',
@@ -56,6 +58,8 @@ class JdbcTelemetrySpanSpec  extends Specification {
         def dataSourceBeanCreatedEventListener= ctx.getBean(DataSourceBeanCreatedEventListener)
         def jdbcTelemetryConfiguration = ctx.getBean(JdbcTelemetryConfiguration)
         def inMemorySpanExporter = ctx.getBean(InMemorySpanExporter)
+        executeSql(ctx, "CREATE TABLE foo (id INT PRIMARY KEY, name VARCHAR(255))")
+        executeSql(ctx, "DROP TABLE foo")
 
         then:
         dataSourceBeanCreatedEventListener
@@ -70,6 +74,14 @@ class JdbcTelemetrySpanSpec  extends Specification {
 
         cleanup:
         ctx.close()
+    }
+
+    private static void executeSql(ApplicationContext ctx, String sql) {
+        ctx.getBean(DataSource).connection.withCloseable { connection ->
+            connection.createStatement().withCloseable { statement ->
+                statement.execute(sql)
+            }
+        }
     }
 
 }

--- a/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/util/Foo.java
+++ b/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/util/Foo.java
@@ -1,9 +1,0 @@
-package io.micronaut.tracing.util;
-
-import io.micronaut.data.annotation.GeneratedValue;
-import io.micronaut.data.annotation.Id;
-import io.micronaut.data.annotation.MappedEntity;
-
-@MappedEntity
-public record Foo(@GeneratedValue @Id Integer id, String name) {
-}

--- a/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry-jdbc/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package io.micronaut.tracing.util;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.context.event.StartupEvent;
 import io.micronaut.tracing.opentelemetry.DefaultOpenTelemetryFactory;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -40,7 +43,20 @@ public class TestDefaultOpenTelemetryFactory {
      */
     @Singleton
     @Primary
+    @Requires(property = "test.open-telemetry.requires-startup-event-publisher", notEquals = "true")
     OpenTelemetry defaultOpenTelemetry(InMemorySpanExporter inMemorySpanExporter) {
+        return createOpenTelemetry(inMemorySpanExporter);
+    }
+
+    @Singleton
+    @Primary
+    @Requires(property = "test.open-telemetry.requires-startup-event-publisher", value = "true")
+    OpenTelemetry defaultOpenTelemetryRequiringStartupEventPublisher(InMemorySpanExporter inMemorySpanExporter,
+                                                                     ApplicationEventPublisher<StartupEvent> ignored) {
+        return createOpenTelemetry(inMemorySpanExporter);
+    }
+
+    private static OpenTelemetry createOpenTelemetry(InMemorySpanExporter inMemorySpanExporter) {
         return OpenTelemetrySdk.builder()
             .setTracerProvider(SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(inMemorySpanExporter))


### PR DESCRIPTION
## Summary
- defer JDBC telemetry configuration lookup until a DataSource is actually wrapped
- add a regression test for eager singleton startup when OpenTelemetry depends on StartupEvent publication
- keep existing JDBC telemetry behavior covered by module tests

## Verification
- ./gradlew --no-daemon --console=plain :micronaut-tracing-opentelemetry-jdbc:test --tests 'io.micronaut.tracing.opentelemetry.instrument.jdbc.JdbcTelemetryBeanCreationSpec'\n- ./gradlew --no-daemon --console=plain :micronaut-tracing-opentelemetry-jdbc:test\n\nResolves #658