### PR TITLE
Fix OpenTracing parent selection for nested HTTP requests

### DIFF
--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -26,6 +26,7 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 import spock.lang.AutoCleanup
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -483,6 +484,45 @@ class HttpTracingSpec extends Specification {
 
             nrOfStartedSpans > 0
             nrOfFinishedSpans == nrOfStartedSpans
+        }
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-tracing/issues/236')
+    void 'test nested HTTP tracing propagates trace context to the nested server span'() {
+        when:
+        HttpResponse<String> response = client.toBlocking().exchange('/traced/nested/John', String)
+
+        then:
+        response
+
+        conditions.eventually {
+            reporter.spans.size() == 4
+
+            List<JaegerSpan> spans = reporter.spans
+            spans.collect { it.context().traceId }.unique().size() == 1
+
+            JaegerSpan nestedClientSpan = spans.find {
+                it.operationName == 'GET /traced/nested/John' && it.tags['http.client']
+            }
+            nestedClientSpan != null
+
+            JaegerSpan nestedServerSpan = spans.find {
+                it.operationName == 'GET /traced/nested/{name}' && it.tags['http.server']
+            }
+            nestedServerSpan != null
+            nestedServerSpan.context().parentId == nestedClientSpan.context().spanId
+
+            JaegerSpan helloClientSpan = spans.find {
+                it.operationName == 'GET /traced/hello/{name}' && it.tags['http.client']
+            }
+            helloClientSpan != null
+            helloClientSpan.context().parentId == nestedServerSpan.context().spanId
+
+            JaegerSpan helloServerSpan = spans.find {
+                it.operationName == 'GET /traced/hello/{name}' && it.tags['http.server']
+            }
+            helloServerSpan != null
+            helloServerSpan.context().parentId == helloClientSpan.context().spanId
         }
     }
 

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
@@ -134,11 +134,14 @@ public abstract sealed class AbstractOpenTracingFilter implements HttpFilter
      * @param spanContext the span context
      * @return the span builder
      */
-    protected SpanBuilder newSpan(HttpRequest<?> request, SpanContext spanContext) {
+    protected SpanBuilder newSpan(HttpRequest<?> request, @Nullable SpanContext spanContext) {
         String spanName = resolveSpanName(request);
         String path = request.getPath();
 
-        SpanBuilder spanBuilder = tracer.buildSpan(spanName).asChildOf(spanContext);
+        SpanBuilder spanBuilder = tracer.buildSpan(spanName);
+        if (spanContext != null) {
+            spanBuilder.asChildOf(spanContext);
+        }
 
         spanBuilder.withTag(TAG_METHOD, request.getMethodName());
         spanBuilder.withTag(TAG_PATH, path);

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -31,7 +31,6 @@ import io.micronaut.tracing.opentracing.OpenTracingPropagationContext;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.noop.NoopTracer;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -73,22 +72,23 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
             return chain.proceed(request);
         }
 
-        Span currentSpan = tracer.activeSpan();
-        SpanBuilder spanBuilder = newSpan(request, initSpanContext(request));
-        if (currentSpan != null) {
-            spanBuilder.asChildOf(currentSpan);
+        SpanContext parentContext = initSpanContext(request);
+        if (parentContext == null) {
+            Span currentSpan = tracer.activeSpan();
+            if (currentSpan != null) {
+                parentContext = currentSpan.context();
+            }
         }
 
-        Span span = spanBuilder.start();
+        Span span = newSpan(request, parentContext).start();
         span.setTag(TAG_HTTP_SERVER, true);
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new OpenTracingPropagationContext(tracer, span))
-            .propagate()) {
-
-            PropagatedContext propagatedContext = PropagatedContext.get();
+        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
+            .plus(new OpenTracingPropagationContext(tracer, span));
+        return propagatedContext.propagate(() -> {
+            PropagatedContext currentContext = PropagatedContext.get();
             return Mono.from(chain.proceed(request))
                 .doOnNext(response -> {
                     tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(response.getHeaders()));
@@ -96,8 +96,8 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
                 })
                 .doOnError(throwable -> setErrorTags(span, throwable))
                 .doOnTerminate(span::finish)
-                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
-        }
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, currentContext));
+        });
     }
 
     @Override
@@ -105,7 +105,7 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         return TRACING.order();
     }
 
-    @NonNull
+    @Nullable
     private SpanContext initSpanContext(@NonNull HttpRequest<?> request) {
         SpanContext spanContext = tracer.extract(
             HTTP_HEADERS,

--- a/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilterSpec.groovy
+++ b/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilterSpec.groovy
@@ -1,0 +1,101 @@
+package io.micronaut.tracing.opentracing.instrument.http
+
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.filter.ServerFilterChain
+import io.opentracing.Scope
+import io.opentracing.Span
+import io.opentracing.SpanContext
+import io.opentracing.Tracer
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import static io.opentracing.propagation.Format.Builtin.HTTP_HEADERS
+
+class OpenTracingServerFilterSpec extends Specification {
+
+    void 'prefers extracted request context over active span'() {
+        given:
+        SpanContext extractedParent = Stub()
+        SpanContext createdSpanContext = Stub()
+        Scope scope = Mock()
+        Span createdSpan = Mock() {
+            2 * context() >> createdSpanContext
+        }
+        Tracer.SpanBuilder spanBuilder = Mock()
+        Tracer tracer = Mock() {
+            1 * extract(HTTP_HEADERS, _) >> extractedParent
+            1 * buildSpan('GET /traced/hello') >> spanBuilder
+            0 * activeSpan()
+        }
+        OpenTracingServerFilter filter = newFilter(tracer)
+        HttpRequest<?> request = HttpRequest.GET('/traced/hello')
+
+        when:
+        Mono.from(filter.doFilter(request, okChain())).block()
+
+        then:
+        1 * spanBuilder.asChildOf(extractedParent) >> spanBuilder
+        1 * spanBuilder.withTag('http.method', 'GET') >> spanBuilder
+        1 * spanBuilder.withTag('http.path', '/traced/hello') >> spanBuilder
+        1 * spanBuilder.start() >> createdSpan
+        1 * createdSpan.setTag('http.server', true)
+        1 * tracer.activateSpan(createdSpan) >> scope
+        1 * tracer.inject(createdSpanContext, HTTP_HEADERS, _)
+        1 * createdSpan.finish()
+        1 * scope.close()
+        request.getAttribute(TraceRequestAttributes.CURRENT_SPAN, Span).orElseThrow().is(createdSpan)
+    }
+
+    void 'falls back to active span when request has no tracing headers'() {
+        given:
+        SpanContext activeSpanContext = Stub()
+        SpanContext createdSpanContext = Stub()
+        Span currentSpan = Stub() {
+            context() >> activeSpanContext
+        }
+        Scope scope = Mock()
+        Span createdSpan = Mock() {
+            2 * context() >> createdSpanContext
+        }
+        Tracer.SpanBuilder spanBuilder = Mock()
+        Tracer tracer = Mock() {
+            1 * extract(HTTP_HEADERS, _) >> null
+            1 * activeSpan() >> currentSpan
+            1 * buildSpan('GET /traced/hello') >> spanBuilder
+        }
+        OpenTracingServerFilter filter = newFilter(tracer)
+        HttpRequest<?> request = HttpRequest.GET('/traced/hello')
+
+        when:
+        Mono.from(filter.doFilter(request, okChain())).block()
+
+        then:
+        1 * spanBuilder.asChildOf(activeSpanContext) >> spanBuilder
+        1 * spanBuilder.withTag('http.method', 'GET') >> spanBuilder
+        1 * spanBuilder.withTag('http.path', '/traced/hello') >> spanBuilder
+        1 * spanBuilder.start() >> createdSpan
+        1 * createdSpan.setTag('http.server', true)
+        1 * tracer.activateSpan(createdSpan) >> scope
+        1 * tracer.inject(createdSpanContext, HTTP_HEADERS, _)
+        1 * createdSpan.finish()
+        1 * scope.close()
+        request.getAttribute(TraceRequestAttributes.CURRENT_SPAN, Span).orElseThrow().is(createdSpan)
+    }
+
+    private static OpenTracingServerFilter newFilter(Tracer tracer) {
+        new OpenTracingServerFilter(tracer, ConversionService.SHARED, null)
+    }
+
+    private static ServerFilterChain okChain() {
+        return new ServerFilterChain() {
+            @Override
+            Publisher<MutableHttpResponse<?>> proceed(HttpRequest<?> request) {
+                return Mono.just(HttpResponse.ok())
+            }
+        }
+    }
+}

--- a/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilterSpec.groovy
+++ b/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilterSpec.groovy
@@ -86,6 +86,43 @@ class OpenTracingServerFilterSpec extends Specification {
         request.getAttribute(TraceRequestAttributes.CURRENT_SPAN, Span).orElseThrow().is(createdSpan)
     }
 
+    void 'finishes span and closes scope when chain errors'() {
+        given:
+        SpanContext extractedParent = Stub()
+        SpanContext createdSpanContext = Stub()
+        Scope scope = Mock()
+        Throwable failure = new IllegalStateException('broken')
+        Span createdSpan = Mock() {
+            1 * context() >> createdSpanContext
+        }
+        Tracer.SpanBuilder spanBuilder = Mock()
+        Tracer tracer = Mock() {
+            1 * extract(HTTP_HEADERS, _) >> extractedParent
+            1 * buildSpan('GET /traced/error') >> spanBuilder
+            0 * activeSpan()
+        }
+        OpenTracingServerFilter filter = newFilter(tracer)
+        HttpRequest<?> request = HttpRequest.GET('/traced/error')
+
+        when:
+        Mono.from(filter.doFilter(request, errorChain(failure))).block()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.is(failure)
+        1 * spanBuilder.asChildOf(extractedParent) >> spanBuilder
+        1 * spanBuilder.withTag('http.method', 'GET') >> spanBuilder
+        1 * spanBuilder.withTag('http.path', '/traced/error') >> spanBuilder
+        1 * spanBuilder.start() >> createdSpan
+        1 * createdSpan.setTag('http.server', true)
+        1 * tracer.activateSpan(createdSpan) >> scope
+        1 * createdSpan.setTag('error', 'broken')
+        1 * createdSpan.finish()
+        1 * scope.close()
+        0 * tracer.inject(_, _, _)
+        request.getAttribute(TraceRequestAttributes.CURRENT_SPAN, Span).orElseThrow().is(createdSpan)
+    }
+
     private static OpenTracingServerFilter newFilter(Tracer tracer) {
         new OpenTracingServerFilter(tracer, ConversionService.SHARED, null)
     }
@@ -95,6 +132,15 @@ class OpenTracingServerFilterSpec extends Specification {
             @Override
             Publisher<MutableHttpResponse<?>> proceed(HttpRequest<?> request) {
                 return Mono.just(HttpResponse.ok())
+            }
+        }
+    }
+
+    private static ServerFilterChain errorChain(Throwable failure) {
+        return new ServerFilterChain() {
+            @Override
+            Publisher<MutableHttpResponse<?>> proceed(HttpRequest<?> request) {
+                return Mono.error(failure)
             }
         }
     }


### PR DESCRIPTION
## Summary
- prefer the extracted HTTP trace context over any active span when creating server spans
- add regression coverage for extracted-parent and active-span fallback behavior
- strengthen the Jaeger nested-request assertions around trace and parent ids

## Verification
- ./gradlew :micronaut-tracing-opentracing:test --tests 'io.micronaut.tracing.opentracing.instrument.http.OpenTracingServerFilterSpec' :micronaut-tracing-jaeger:test --tests 'io.micronaut.tracing.jaeger.HttpTracingSpec'

Resolves #236