### PR TITLE
Avoid NPE when HTTP client telemetry context is missing

### DIFF
--- a/tests/kotlin-tests/build.gradle
+++ b/tests/kotlin-tests/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     testImplementation mn.kotlinx.coroutines.core
     testImplementation mn.kotlinx.coroutines.reactor
+    testImplementation projects.micronautTracingOpentelemetryHttp
 
     testImplementation mn.micronaut.http.server.netty
     testImplementation mnTest.micronaut.test.junit5
@@ -23,4 +24,3 @@ dependencies {
     testImplementation mnSerde.micronaut.serde.jackson
     testImplementation(mnTest.junit.platform.launcher)
 }
-

--- a/tests/kotlin-tests/src/test/kotlin/reactor/OpenTelemetryCoroutineHttpClientSpec.kt
+++ b/tests/kotlin-tests/src/test/kotlin/reactor/OpenTelemetryCoroutineHttpClientSpec.kt
@@ -1,0 +1,66 @@
+package reactor
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class OpenTelemetryCoroutineHttpClientSpec {
+
+    @Test
+    fun testOpenTelemetryClientFilterWithSuspendClient() {
+        val embeddedServer = ApplicationContext.run(
+            EmbeddedServer::class.java,
+            mapOf(
+                "otelcoroutineclient.enabled" to "true",
+                "micronaut.application.name" to "otel-coroutine-client-test",
+                "otel.traces.exporter" to "none",
+                "otel.metrics.exporter" to "none",
+                "otel.logs.exporter" to "none",
+                "otel.register.global" to "false",
+                "micronaut.http.client.read-timeout" to "30s"
+            )
+        )
+        val client = HttpClient.create(embeddedServer.url)
+        try {
+            val response = client.toBlocking().retrieve("/otel-coroutine-client/call", String::class.java)
+
+            assertEquals("ok", response)
+        } finally {
+            client.close()
+            embeddedServer.stop()
+        }
+    }
+}
+
+@Requires(property = "otelcoroutineclient.enabled")
+@Controller("/otel-coroutine-client")
+class OpenTelemetryCoroutineClientController(private val client: OpenTelemetryCoroutineDownstreamClient) {
+
+    @Get("/call")
+    suspend fun call(): String {
+        return withContext(Dispatchers.IO) {
+            client.downstream()
+        }
+    }
+
+    @Get("/downstream")
+    suspend fun downstream(): String {
+        return "ok"
+    }
+}
+
+@Requires(property = "otelcoroutineclient.enabled")
+@Client("/otel-coroutine-client")
+interface OpenTelemetryCoroutineDownstreamClient {
+
+    @Get("/downstream")
+    suspend fun downstream(): String
+}

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
@@ -18,7 +18,6 @@ package io.micronaut.tracing.opentelemetry.instrument.http.client;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpResponseProvider;
@@ -96,7 +95,6 @@ public final class OpenTelemetryClientFilter extends AbstractOpenTelemetryFilter
                 .plus(new OpenTelemetryPropagationContext(context))
                 .propagate()) {
 
-                var propagatedContext = PropagatedContext.get();
                 return Mono.from(chain.proceed(request))
                     .doOnNext(mutableHttpResponse -> instrumenter.end(context, request, mutableHttpResponse, null))
                     .doOnError(throwable -> {
@@ -105,8 +103,7 @@ public final class OpenTelemetryClientFilter extends AbstractOpenTelemetryFilter
                         span.setStatus(StatusCode.ERROR);
                         HttpResponse<?> response = findResponseInThrowable(throwable).orElse(null);
                         instrumenter.end(context, request, response, throwable);
-                    })
-                    .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
+                    });
 
             }
         }

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
@@ -82,6 +82,9 @@ public final class OpenTelemetryClientFilter extends AbstractOpenTelemetryFilter
         }
 
         Context context = instrumenter.start(parentContext, request);
+        if (context == null) {
+            return chain.proceed(request);
+        }
 
         try (Scope ignored = context.makeCurrent()) {
             handleContinueSpan(request);

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
@@ -18,6 +18,7 @@ package io.micronaut.tracing.opentelemetry.instrument.http.client;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpResponseProvider;
@@ -95,6 +96,7 @@ public final class OpenTelemetryClientFilter extends AbstractOpenTelemetryFilter
                 .plus(new OpenTelemetryPropagationContext(context))
                 .propagate()) {
 
+                var propagatedContext = PropagatedContext.get();
                 return Mono.from(chain.proceed(request))
                     .doOnNext(mutableHttpResponse -> instrumenter.end(context, request, mutableHttpResponse, null))
                     .doOnError(throwable -> {
@@ -103,7 +105,8 @@ public final class OpenTelemetryClientFilter extends AbstractOpenTelemetryFilter
                         span.setStatus(StatusCode.ERROR);
                         HttpResponse<?> response = findResponseInThrowable(throwable).orElse(null);
                         instrumenter.end(context, request, response, throwable);
-                    });
+                    })
+                    .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
 
             }
         }

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilter.java
@@ -81,6 +81,8 @@ public final class OpenTelemetryClientFilter extends AbstractOpenTelemetryFilter
             return chain.proceed(request);
         }
 
+        // Some instrumenter implementations may choose not to create telemetry state for a request.
+        // In that case, fail open by proceeding without making a context current or ending a span.
         Context context = instrumenter.start(parentContext, request);
         if (context == null) {
             return chain.proceed(request);

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilterSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilterSpec.groovy
@@ -8,6 +8,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import reactor.core.publisher.Mono
 import spock.lang.Specification
 
+import java.time.Duration
+
 class OpenTelemetryClientFilterSpec extends Specification {
 
     void 'falls back to the original request when the instrumenter returns no context'() {
@@ -19,7 +21,7 @@ class OpenTelemetryClientFilterSpec extends Specification {
         def filter = new OpenTelemetryClientFilter(null, instrumenter)
 
         when:
-        HttpResponse<?> result = Mono.from(filter.doFilter(request, chain)).block()
+        HttpResponse<?> result = Mono.from(filter.doFilter(request, chain)).block(Duration.ofSeconds(3))
 
         then:
         1 * instrumenter.shouldStart(_, request) >> true

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilterSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/client/OpenTelemetryClientFilterSpec.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.tracing.opentelemetry.instrument.http.client
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.filter.ClientFilterChain
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+class OpenTelemetryClientFilterSpec extends Specification {
+
+    void 'falls back to the original request when the instrumenter returns no context'() {
+        given:
+        MutableHttpRequest<Object> request = HttpRequest.GET('/test')
+        HttpResponse<Object> response = HttpResponse.ok()
+        ClientFilterChain chain = Mock()
+        Instrumenter<MutableHttpRequest<?>, Object> instrumenter = Mock()
+        def filter = new OpenTelemetryClientFilter(null, instrumenter)
+
+        when:
+        HttpResponse<?> result = Mono.from(filter.doFilter(request, chain)).block()
+
+        then:
+        1 * instrumenter.shouldStart(_, request) >> true
+        1 * instrumenter.start(_, request) >> null
+        1 * chain.proceed(request) >> Mono.just(response)
+        0 * instrumenter.end(_, _, _, _)
+        result == response
+    }
+}


### PR DESCRIPTION
## Summary
- fail open in the HTTP client tracing filter when the OpenTelemetry instrumenter returns no context
- add a focused regression spec that simulates a null client telemetry context

## Testing
- `./gradlew :micronaut-tracing-opentelemetry-http:test --tests '*OpenTelemetryClientFilterSpec'`
- `./gradlew :micronaut-tracing-opentelemetry-http:test` *(fails in existing `OpenTelemetryHttpSpec` on this runner because it expects `server.address == "localhost"`, but the environment reports the container hostname instead)*

Resolves #287
