### PR TITLE
Fix Jaeger trace ID propagation for Netty response logs

### DIFF
--- a/tracing-jaeger/build.gradle
+++ b/tracing-jaeger/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     // okio is a transitive dependency of io.jaegertracing:jaeger-thrift via okhttp3
     // https://osv.dev/GHSA-w33c-445m-f8w7
     implementation(libs.okio)
+    testImplementation mnLogging.logback.classic
     testImplementation mnReactor.micronaut.reactor
     testImplementation mn.micronaut.http.server.netty
     testRuntimeOnly mnSerde.micronaut.serde.jackson

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -1,5 +1,9 @@
 package io.micronaut.tracing.jaeger
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
 import io.jaegertracing.internal.JaegerSpan
 import io.jaegertracing.internal.JaegerTracer
 import io.jaegertracing.internal.metrics.InMemoryMetricsFactory
@@ -21,6 +25,7 @@ import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.tracing.annotation.ContinueSpan
 import io.opentracing.Tracer
 import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -31,6 +36,7 @@ import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 
 import static io.micronaut.http.HttpStatus.TOO_MANY_REQUESTS
@@ -721,6 +727,39 @@ class HttpTracingSpec extends Specification {
         response.body.get() == "1"
     }
 
+    void 'test netty client logs use current reactive request trace id'() {
+        given:
+        TracedController.reactiveClientTraceIds.clear()
+        ClientLogAppender.events.clear()
+        def logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger('io.micronaut.http.client.netty.DefaultHttpClient')
+        def previousLevel = logger.level
+        def appender = new ClientLogAppender()
+        appender.context = (LoggerContext) LoggerFactory.getILoggerFactory()
+        appender.start()
+        logger.addAppender(appender)
+        logger.level = Level.DEBUG
+
+        when:
+        new URL(embeddedServer.URL, '/traced/reactiveClient/John').text
+        new URL(embeddedServer.URL, '/traced/reactiveClient/Jane').text
+
+        then:
+        conditions.eventually {
+            TracedController.reactiveClientTraceIds.size() == 2
+            clientRequestEvents.size() >= 2
+        }
+        TracedController.reactiveClientTraceIds[0] != TracedController.reactiveClientTraceIds[1]
+        clientRequestTraceId('/traced/hello/John') == TracedController.reactiveClientTraceIds[0]
+        clientRequestTraceId('/traced/hello/Jane') == TracedController.reactiveClientTraceIds[1]
+
+        cleanup:
+        logger?.level = previousLevel
+        if (logger && appender) {
+            logger.detachAppender(appender)
+            appender.stop()
+        }
+    }
+
     private long getJaegerMetric(String name, Map tags = [:]) {
         context.getBean(InMemoryMetricsFactory).getCounter('jaeger_tracer_' + name, tags)
     }
@@ -741,6 +780,8 @@ class HttpTracingSpec extends Specification {
 
         @Inject
         TracedClient tracedClient
+
+        static final List<String> reactiveClientTraceIds = new CopyOnWriteArrayList<>()
 
         boolean failed
 
@@ -867,6 +908,13 @@ class HttpTracingSpec extends Specification {
             Mono.just(10)
         }
 
+        @Get('/reactiveClient/{name}')
+        @SingleResult
+        Publisher<String> reactiveClient(String name) {
+            reactiveClientTraceIds.add(spanCustomizer.activeSpan()?.context()?.toTraceId())
+            tracedClient.continuedRx(name)
+        }
+
         @Get('/quota-error')
         @SingleResult
         Publisher<String> quotaError() {
@@ -929,5 +977,25 @@ class HttpTracingSpec extends Specification {
         @Get('/nestedReactive2/{name}')
         @SingleResult
         Publisher<String> nestedReactive2(String name)
+    }
+
+    private List<ILoggingEvent> getClientRequestEvents() {
+        ClientLogAppender.events.findAll {
+            it.formattedMessage.contains('Sending HTTP GET') && it.formattedMessage.contains('/traced/hello/')
+        }
+    }
+
+    private String clientRequestTraceId(String path) {
+        clientRequestEvents.find { it.formattedMessage.contains(path) }?.mdcPropertyMap?.get('traceId')
+    }
+
+    static class ClientLogAppender extends AppenderBase<ILoggingEvent> {
+
+        static final List<ILoggingEvent> events = new CopyOnWriteArrayList<>()
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            events.add(eventObject)
+        }
     }
 }

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -744,13 +744,12 @@ class HttpTracingSpec extends Specification {
         new URL(embeddedServer.URL, '/traced/reactiveClient/Jane').text
 
         then:
-        conditions.eventually {
+        new PollingConditions(timeout: 5).eventually {
             TracedController.reactiveClientTraceIds.size() == 2
-            clientRequestEvents.size() >= 2
+            clientRequestTraceId('/traced/hello/John') == TracedController.reactiveClientTraceIds[0]
+            clientRequestTraceId('/traced/hello/Jane') == TracedController.reactiveClientTraceIds[1]
+            TracedController.reactiveClientTraceIds[0] != TracedController.reactiveClientTraceIds[1]
         }
-        TracedController.reactiveClientTraceIds[0] != TracedController.reactiveClientTraceIds[1]
-        clientRequestTraceId('/traced/hello/John') == TracedController.reactiveClientTraceIds[0]
-        clientRequestTraceId('/traced/hello/Jane') == TracedController.reactiveClientTraceIds[1]
 
         cleanup:
         logger?.level = previousLevel

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -727,7 +727,7 @@ class HttpTracingSpec extends Specification {
         response.body.get() == "1"
     }
 
-    void 'test netty client logs use current reactive request trace id'() {
+    void 'test netty client request and response logs use current reactive request trace id'() {
         given:
         TracedController.reactiveClientTraceIds.clear()
         ClientLogAppender.events.clear()
@@ -737,7 +737,7 @@ class HttpTracingSpec extends Specification {
         appender.context = (LoggerContext) LoggerFactory.getILoggerFactory()
         appender.start()
         logger.addAppender(appender)
-        logger.level = Level.DEBUG
+        logger.level = Level.TRACE
 
         when:
         new URL(embeddedServer.URL, '/traced/reactiveClient/John').text
@@ -748,6 +748,8 @@ class HttpTracingSpec extends Specification {
             TracedController.reactiveClientTraceIds.size() == 2
             clientRequestTraceId('/traced/hello/John') == TracedController.reactiveClientTraceIds[0]
             clientRequestTraceId('/traced/hello/Jane') == TracedController.reactiveClientTraceIds[1]
+            clientResponseTraceId('/traced/hello/John') == TracedController.reactiveClientTraceIds[0]
+            clientResponseTraceId('/traced/hello/Jane') == TracedController.reactiveClientTraceIds[1]
             TracedController.reactiveClientTraceIds[0] != TracedController.reactiveClientTraceIds[1]
         }
 
@@ -986,6 +988,16 @@ class HttpTracingSpec extends Specification {
 
     private String clientRequestTraceId(String path) {
         clientRequestEvents.find { it.formattedMessage.contains(path) }?.mdcPropertyMap?.get('traceId')
+    }
+
+    private List<ILoggingEvent> getClientResponseEvents() {
+        ClientLogAppender.events.findAll {
+            it.formattedMessage.contains('HTTP Client Response Received') && it.formattedMessage.contains('/traced/hello/')
+        }
+    }
+
+    private String clientResponseTraceId(String path) {
+        clientResponseEvents.find { it.formattedMessage.contains(path) }?.mdcPropertyMap?.get('traceId')
     }
 
     static class ClientLogAppender extends AppenderBase<ILoggingEvent> {

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/OpenTracingInvocationInstrumenterSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/OpenTracingInvocationInstrumenterSpec.groovy
@@ -1,9 +1,11 @@
 package io.micronaut.tracing.jaeger
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.tracing.opentracing.OpenTracingPropagationContext
 import io.opentracing.Scope
 import io.opentracing.Span
 import io.opentracing.Tracer
+import org.slf4j.MDC
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import spock.lang.Specification
@@ -38,5 +40,60 @@ class OpenTracingInvocationInstrumenterSpec extends Specification {
         then: 'there should be no active span after it was finished'
         combined.split(", ").sort() == words.sort()
         tracer.activeSpan() == null
+    }
+
+    void "test out of order context restore does not restore stale MDC"() {
+        given: 'Jaeger tracer is enabled'
+        ApplicationContext context = ApplicationContext.run('tracing.jaeger.enabled': true)
+        Tracer tracer = context.getBean(Tracer)
+        Map previousMdc = MDC.getCopyOfContextMap()
+        MDC.put('traceId', 'previous-trace')
+        Span firstSpan = tracer.buildSpan('first').start()
+        Span secondSpan = tracer.buildSpan('second').start()
+        def firstContext = new OpenTracingPropagationContext(tracer, firstSpan)
+        def secondContext = new OpenTracingPropagationContext(tracer, secondSpan)
+
+        expect: 'no active span'
+        tracer.activeSpan() == null
+        MDC.get('traceId') == 'previous-trace'
+
+        when: 'two contexts are activated'
+        Scope firstScope = firstContext.updateThreadContext()
+        Scope secondScope = secondContext.updateThreadContext()
+
+        then:
+        tracer.activeSpan() == secondSpan
+        MDC.get('traceId') == secondSpan.context().toTraceId()
+
+        when: 'the first context is restored before the second'
+        firstContext.restoreThreadContext(firstScope)
+
+        then: 'the current MDC is retained instead of restoring a stale value'
+        tracer.activeSpan() == secondSpan
+        MDC.get('traceId') == secondSpan.context().toTraceId()
+
+        when: 'contexts are restored in stack order'
+        secondContext.restoreThreadContext(secondScope)
+
+        then:
+        tracer.activeSpan() == firstSpan
+        MDC.get('traceId') == firstSpan.context().toTraceId()
+
+        when:
+        firstContext.restoreThreadContext(firstScope)
+
+        then:
+        tracer.activeSpan() == null
+        MDC.get('traceId') == 'previous-trace'
+
+        cleanup:
+        if (previousMdc == null) {
+            MDC.clear()
+        } else {
+            MDC.setContextMap(previousMdc)
+        }
+        secondSpan.finish()
+        firstSpan.finish()
+        context.close()
     }
 }

--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/OpenTracingInvocationInstrumenterSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/OpenTracingInvocationInstrumenterSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.tracing.jaeger
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.propagation.PropagatedContext
 import io.micronaut.tracing.opentracing.OpenTracingPropagationContext
 import io.opentracing.Scope
 import io.opentracing.Span
@@ -42,7 +43,7 @@ class OpenTracingInvocationInstrumenterSpec extends Specification {
         tracer.activeSpan() == null
     }
 
-    void "test out of order context restore does not restore stale MDC"() {
+    void "test propagated OpenTracing context keeps one active span element"() {
         given: 'Jaeger tracer is enabled'
         ApplicationContext context = ApplicationContext.run('tracing.jaeger.enabled': true)
         Tracer tracer = context.getBean(Tracer)
@@ -50,37 +51,47 @@ class OpenTracingInvocationInstrumenterSpec extends Specification {
         MDC.put('traceId', 'previous-trace')
         Span firstSpan = tracer.buildSpan('first').start()
         Span secondSpan = tracer.buildSpan('second').start()
-        def firstContext = new OpenTracingPropagationContext(tracer, firstSpan)
-        def secondContext = new OpenTracingPropagationContext(tracer, secondSpan)
+        PropagatedContext firstContext = OpenTracingPropagationContext.withSpan(PropagatedContext.getOrEmpty(), tracer, firstSpan)
+        PropagatedContext secondContext = OpenTracingPropagationContext.withSpan(firstContext, tracer, secondSpan)
+        PropagatedContext duplicatedContext = PropagatedContext.getOrEmpty()
+                .plus(new OpenTracingPropagationContext(tracer, firstSpan))
+                .plus(new OpenTracingPropagationContext(tracer, secondSpan))
+        PropagatedContext normalizedContext = OpenTracingPropagationContext.withSpan(duplicatedContext, tracer, secondSpan)
 
         expect: 'no active span'
         tracer.activeSpan() == null
         MDC.get('traceId') == 'previous-trace'
+        firstContext.findAll(OpenTracingPropagationContext).toList().size() == 1
+        firstContext.get(OpenTracingPropagationContext).span() == firstSpan
+        secondContext.findAll(OpenTracingPropagationContext).toList().size() == 1
+        secondContext.get(OpenTracingPropagationContext).span() == secondSpan
+        duplicatedContext.findAll(OpenTracingPropagationContext).toList().size() == 2
+        normalizedContext.findAll(OpenTracingPropagationContext).toList().size() == 1
+        normalizedContext.get(OpenTracingPropagationContext).span() == secondSpan
 
-        when: 'two contexts are activated'
-        Scope firstScope = firstContext.updateThreadContext()
-        Scope secondScope = secondContext.updateThreadContext()
+        when: 'the first context is activated'
+        PropagatedContext.Scope firstScope = firstContext.propagate()
+
+        then:
+        tracer.activeSpan() == firstSpan
+        MDC.get('traceId') == firstSpan.context().toTraceId()
+
+        when: 'the OpenTracing context element is replaced by another span'
+        PropagatedContext.Scope secondScope = secondContext.propagate()
 
         then:
         tracer.activeSpan() == secondSpan
         MDC.get('traceId') == secondSpan.context().toTraceId()
 
-        when: 'the first context is restored before the second'
-        firstContext.restoreThreadContext(firstScope)
-
-        then: 'the current MDC is retained instead of restoring a stale value'
-        tracer.activeSpan() == secondSpan
-        MDC.get('traceId') == secondSpan.context().toTraceId()
-
         when: 'contexts are restored in stack order'
-        secondContext.restoreThreadContext(secondScope)
+        secondScope.close()
 
         then:
         tracer.activeSpan() == firstSpan
         MDC.get('traceId') == firstSpan.context().toTraceId()
 
         when:
-        firstContext.restoreThreadContext(firstScope)
+        firstScope.close()
 
         then:
         tracer.activeSpan() == null

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/OpenTracingPropagationContext.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/OpenTracingPropagationContext.java
@@ -16,10 +16,14 @@
 package io.micronaut.tracing.opentracing;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.propagation.ThreadPropagatedContextElement;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+
+import java.util.List;
 
 /**
  * The open tracing propagated context.
@@ -32,6 +36,27 @@ import io.opentracing.Tracer;
 public record OpenTracingPropagationContext(Tracer tracer,
                                             Span span) implements ThreadPropagatedContextElement<Scope> {
 
+    /**
+     * Creates a propagated context with the current OpenTracing span.
+     *
+     * @param context The propagated context
+     * @param tracer  The tracer
+     * @param span    The span
+     * @return A propagated context with a single OpenTracing context element
+     */
+    @NonNull
+    public static PropagatedContext withSpan(@NonNull PropagatedContext context,
+                                             @NonNull Tracer tracer,
+                                             @NonNull Span span) {
+        OpenTracingPropagationContext element = new OpenTracingPropagationContext(tracer, span);
+        PropagatedContext newContext = context;
+        List<OpenTracingPropagationContext> existingContexts = context.findAll(OpenTracingPropagationContext.class).toList();
+        for (OpenTracingPropagationContext existingContext : existingContexts) {
+            newContext = newContext.minus(existingContext);
+        }
+        return newContext.plus(element);
+    }
+
     @Override
     public Scope updateThreadContext() {
         return tracer.activateSpan(span);
@@ -39,8 +64,6 @@ public record OpenTracingPropagationContext(Tracer tracer,
 
     @Override
     public void restoreThreadContext(Scope oldScope) {
-        if (tracer.activeSpan() == span) {
-            oldScope.close();
-        }
+        oldScope.close();
     }
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/OpenTracingPropagationContext.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/OpenTracingPropagationContext.java
@@ -39,6 +39,8 @@ public record OpenTracingPropagationContext(Tracer tracer,
 
     @Override
     public void restoreThreadContext(Scope oldScope) {
-        oldScope.close();
+        if (tracer.activeSpan() == span) {
+            oldScope.close();
+        }
     }
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
@@ -18,6 +18,7 @@ package io.micronaut.tracing.opentracing.instrument.http;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -157,5 +158,16 @@ public abstract sealed class AbstractOpenTracingFilter implements HttpFilter
      */
     protected boolean shouldExclude(@Nullable String path) {
         return pathExclusionTest != null && path != null && pathExclusionTest.test(path);
+    }
+
+    /**
+     * Opens a thread-local propagation scope for reactive HTTP filter subscription work.
+     *
+     * @param propagatedContext The context to propagate
+     * @return the opened propagation scope
+     */
+    @SuppressWarnings("deprecation")
+    protected static PropagatedContext.Scope propagationScope(PropagatedContext propagatedContext) {
+        return propagatedContext.propagate();
     }
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
@@ -143,6 +143,8 @@ public abstract sealed class AbstractOpenTracingFilter implements HttpFilter
         SpanBuilder spanBuilder = tracer.buildSpan(spanName);
         if (spanContext != null) {
             spanBuilder.asChildOf(spanContext);
+        } else {
+            spanBuilder.ignoreActiveSpan();
         }
 
         spanBuilder.withTag(TAG_METHOD, request.getMethodName());

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
@@ -23,6 +23,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.filter.HttpFilter;
+import io.micronaut.tracing.opentracing.OpenTracingPropagationContext;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -158,6 +159,16 @@ public abstract sealed class AbstractOpenTracingFilter implements HttpFilter
      */
     protected boolean shouldExclude(@Nullable String path) {
         return pathExclusionTest != null && path != null && pathExclusionTest.test(path);
+    }
+
+    /**
+     * Creates the propagated context for the current OpenTracing span.
+     *
+     * @param span The span to propagate
+     * @return The propagated context
+     */
+    protected PropagatedContext propagationContext(Span span) {
+        return OpenTracingPropagationContext.withSpan(PropagatedContext.getOrEmpty(), tracer, span);
     }
 
     /**

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -18,6 +18,7 @@ package io.micronaut.tracing.opentracing.instrument.http;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.http.HttpResponse;
@@ -91,17 +92,23 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
             .plus(new OpenTracingPropagationContext(tracer, span))
             .propagate()) {
 
+            PropagatedContext propagatedContext = PropagatedContext.get();
             tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(request.getHeaders()));
-            return Mono.from(chain.proceed(request))
-                .doOnNext(httpResponse -> setResponseTags(request, httpResponse, span))
-                .doOnError(throwable -> {
-                    if (throwable instanceof HttpClientResponseException e) {
-                        HttpResponse<?> response = e.getResponse();
-                        setResponseTags(request, response, span);
-                    }
-                    setErrorTags(span, throwable);
-                })
-                .doOnTerminate(span::finish);
+            return Mono.using(
+                propagatedContext::propagate,
+                ignored -> Mono.from(chain.proceed(request))
+                    .doOnNext(httpResponse -> setResponseTags(request, httpResponse, span))
+                    .doOnError(throwable -> {
+                        if (throwable instanceof HttpClientResponseException e) {
+                            HttpResponse<?> response = e.getResponse();
+                            setResponseTags(request, response, span);
+                        }
+                        setErrorTags(span, throwable);
+                    })
+                    .doOnTerminate(span::finish)
+                    .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
+                PropagatedContext.Scope::close
+            );
 
         }
     }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -103,7 +103,7 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
                         }
                         setErrorTags(span, throwable);
                     })
-                    .doOnTerminate(span::finish)
+                    .doFinally(signalType -> span.finish())
                     .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
                 PropagatedContext.Scope::close
             );

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -93,7 +93,7 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
         return propagatedContext.propagate(() -> {
             tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(request.getHeaders()));
             return Mono.using(
-                propagatedContext::propagate,
+                () -> propagationScope(propagatedContext),
                 ignored -> Mono.from(chain.proceed(request))
                     .doOnNext(httpResponse -> setResponseTags(request, httpResponse, span))
                     .doOnError(throwable -> {

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -95,7 +95,7 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
             PropagatedContext propagatedContext = PropagatedContext.get();
             tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(request.getHeaders()));
             return Mono.using(
-                propagatedContext::propagate,
+                () -> propagate(propagatedContext),
                 ignored -> Mono.from(chain.proceed(request))
                     .doOnNext(httpResponse -> setResponseTags(request, httpResponse, span))
                     .doOnError(throwable -> {
@@ -111,5 +111,10 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
             );
 
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static PropagatedContext.Scope propagate(PropagatedContext propagatedContext) {
+        return propagatedContext.propagate();
     }
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -88,23 +88,21 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
         request.setAttribute(CURRENT_SPAN, span);
 
         PropagatedContext propagatedContext = propagationContext(span);
-        return propagatedContext.propagate(() -> {
-            tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(request.getHeaders()));
-            return Mono.using(
-                () -> propagationScope(propagatedContext),
-                ignored -> Mono.from(chain.proceed(request))
-                    .doOnNext(httpResponse -> setResponseTags(request, httpResponse, span))
-                    .doOnError(throwable -> {
-                        if (throwable instanceof HttpClientResponseException e) {
-                            HttpResponse<?> response = e.getResponse();
-                            setResponseTags(request, response, span);
-                        }
-                        setErrorTags(span, throwable);
-                    })
-                    .doFinally(signalType -> span.finish())
-                    .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
-                PropagatedContext.Scope::close
-            );
-        });
+        tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(request.getHeaders()));
+        return Mono.using(
+            () -> propagationScope(propagatedContext),
+            ignored -> Mono.from(chain.proceed(request))
+                .doOnNext(httpResponse -> setResponseTags(request, httpResponse, span))
+                .doOnError(throwable -> {
+                    if (throwable instanceof HttpClientResponseException e) {
+                        HttpResponse<?> response = e.getResponse();
+                        setResponseTags(request, response, span);
+                    }
+                    setErrorTags(span, throwable);
+                })
+                .doFinally(signalType -> span.finish())
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
+            PropagatedContext.Scope::close
+        );
     }
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -27,7 +27,6 @@ import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.filter.ClientFilterChain;
 import io.micronaut.http.filter.HttpClientFilter;
-import io.micronaut.tracing.opentracing.OpenTracingPropagationContext;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -88,8 +87,7 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 
-        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
-            .plus(new OpenTracingPropagationContext(tracer, span));
+        PropagatedContext propagatedContext = propagationContext(span);
         return propagatedContext.propagate(() -> {
             tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(request.getHeaders()));
             return Mono.using(

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -88,14 +88,12 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new OpenTracingPropagationContext(tracer, span))
-            .propagate()) {
-
-            PropagatedContext propagatedContext = PropagatedContext.get();
+        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
+            .plus(new OpenTracingPropagationContext(tracer, span));
+        return propagatedContext.propagate(() -> {
             tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(request.getHeaders()));
             return Mono.using(
-                () -> propagate(propagatedContext),
+                propagatedContext::propagate,
                 ignored -> Mono.from(chain.proceed(request))
                     .doOnNext(httpResponse -> setResponseTags(request, httpResponse, span))
                     .doOnError(throwable -> {
@@ -109,12 +107,6 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
                     .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
                 PropagatedContext.Scope::close
             );
-
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    private static PropagatedContext.Scope propagate(PropagatedContext propagatedContext) {
-        return propagatedContext.propagate();
+        });
     }
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -88,20 +88,24 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 
-        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
-            .plus(new OpenTracingPropagationContext(tracer, span));
-        return propagatedContext.propagate(() -> Mono.using(
-            propagatedContext::propagate,
-            ignored -> Mono.from(chain.proceed(request))
-                .doOnNext(response -> {
-                    tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(response.getHeaders()));
-                    setResponseTags(request, response, span);
-                })
-                .doOnError(throwable -> setErrorTags(span, throwable))
-                .doFinally(signalType -> span.finish())
-                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
-            PropagatedContext.Scope::close
-        ));
+        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
+            .plus(new OpenTracingPropagationContext(tracer, span))
+            .propagate()) {
+
+            PropagatedContext propagatedContext = PropagatedContext.get();
+            return Mono.using(
+                () -> propagate(propagatedContext),
+                ignored -> Mono.from(chain.proceed(request))
+                    .doOnNext(response -> {
+                        tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(response.getHeaders()));
+                        setResponseTags(request, response, span);
+                    })
+                    .doOnError(throwable -> setErrorTags(span, throwable))
+                    .doFinally(signalType -> span.finish())
+                    .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
+                PropagatedContext.Scope::close
+            );
+        }
     }
 
     @Override
@@ -117,6 +121,11 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         );
         request.setAttribute(CURRENT_SPAN_CONTEXT, spanContext);
         return spanContext;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static PropagatedContext.Scope propagate(PropagatedContext propagatedContext) {
+        return propagatedContext.propagate();
     }
 
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -74,12 +74,6 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         }
 
         SpanContext parentContext = initSpanContext(request);
-        if (parentContext == null) {
-            Span currentSpan = tracer.activeSpan();
-            if (currentSpan != null) {
-                parentContext = currentSpan.context();
-            }
-        }
 
         Span span = newSpan(request, parentContext).start();
         span.setTag(TAG_HTTP_SERVER, true);
@@ -88,7 +82,7 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         request.setAttribute(CURRENT_SPAN, span);
 
         PropagatedContext propagatedContext = propagationContext(span);
-        return propagatedContext.propagate(() -> Mono.using(
+        return Mono.using(
             () -> propagationScope(propagatedContext),
             ignored -> Mono.from(chain.proceed(request))
                 .doOnNext(response -> {
@@ -99,7 +93,7 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
                 .doFinally(signalType -> span.finish())
                 .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
             PropagatedContext.Scope::close
-        ));
+        );
     }
 
     @Override

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -88,24 +88,20 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new OpenTracingPropagationContext(tracer, span))
-            .propagate()) {
-
-            PropagatedContext propagatedContext = PropagatedContext.get();
-            return Mono.using(
-                () -> propagate(propagatedContext),
-                ignored -> Mono.from(chain.proceed(request))
-                    .doOnNext(response -> {
-                        tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(response.getHeaders()));
-                        setResponseTags(request, response, span);
-                    })
-                    .doOnError(throwable -> setErrorTags(span, throwable))
-                    .doFinally(signalType -> span.finish())
-                    .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
-                PropagatedContext.Scope::close
-            );
-        }
+        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
+            .plus(new OpenTracingPropagationContext(tracer, span));
+        return propagatedContext.propagate(() -> Mono.using(
+            propagatedContext::propagate,
+            ignored -> Mono.from(chain.proceed(request))
+                .doOnNext(response -> {
+                    tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(response.getHeaders()));
+                    setResponseTags(request, response, span);
+                })
+                .doOnError(throwable -> setErrorTags(span, throwable))
+                .doFinally(signalType -> span.finish())
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
+            PropagatedContext.Scope::close
+        ));
     }
 
     @Override
@@ -121,11 +117,6 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         );
         request.setAttribute(CURRENT_SPAN_CONTEXT, spanContext);
         return spanContext;
-    }
-
-    @SuppressWarnings("deprecation")
-    private static PropagatedContext.Scope propagate(PropagatedContext propagatedContext) {
-        return propagatedContext.propagate();
     }
 
 }

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -91,7 +91,7 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
             .plus(new OpenTracingPropagationContext(tracer, span));
         return propagatedContext.propagate(() -> Mono.using(
-            propagatedContext::propagate,
+            () -> propagationScope(propagatedContext),
             ignored -> Mono.from(chain.proceed(request))
                 .doOnNext(response -> {
                     tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(response.getHeaders()));

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -27,7 +27,6 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
-import io.micronaut.tracing.opentracing.OpenTracingPropagationContext;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -88,8 +87,7 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 
-        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
-            .plus(new OpenTracingPropagationContext(tracer, span));
+        PropagatedContext propagatedContext = propagationContext(span);
         return propagatedContext.propagate(() -> Mono.using(
             () -> propagationScope(propagatedContext),
             ignored -> Mono.from(chain.proceed(request))

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -90,17 +90,18 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
 
         PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
             .plus(new OpenTracingPropagationContext(tracer, span));
-        return propagatedContext.propagate(() -> {
-            PropagatedContext currentContext = PropagatedContext.get();
-            return Mono.from(chain.proceed(request))
+        return propagatedContext.propagate(() -> Mono.using(
+            propagatedContext::propagate,
+            ignored -> Mono.from(chain.proceed(request))
                 .doOnNext(response -> {
                     tracer.inject(span.context(), HTTP_HEADERS, new HttpHeadersTextMap(response.getHeaders()));
                     setResponseTags(request, response, span);
                 })
                 .doOnError(throwable -> setErrorTags(span, throwable))
-                .doOnTerminate(span::finish)
-                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, currentContext));
-        });
+                .doFinally(signalType -> span.finish())
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)),
+            PropagatedContext.Scope::close
+        ));
     }
 
     @Override

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/interceptor/NewSpanTraceInterceptor.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/interceptor/NewSpanTraceInterceptor.java
@@ -74,8 +74,10 @@ public final class NewSpanTraceInterceptor extends AbstractTraceInterceptor {
         Span span = builder.start();
         populateTags(context, span);
 
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new OpenTracingPropagationContext(tracer, span))
+        try (PropagatedContext.Scope ignore = OpenTracingPropagationContext.withSpan(
+                PropagatedContext.getOrEmpty(),
+                tracer,
+                span)
             .propagate()) {
 
             populateTags(context, span);

--- a/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingFilterCancellationSpec.groovy
+++ b/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingFilterCancellationSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.tracing.opentracing.instrument.http
+
+import io.jaegertracing.internal.JaegerSpan
+import io.jaegertracing.internal.reporters.InMemoryReporter
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.filter.ClientFilterChain
+import io.micronaut.http.filter.ServerFilterChain
+import io.opentracing.Tracer
+import reactor.core.publisher.Mono
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class OpenTracingFilterCancellationSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context
+
+    InMemoryReporter reporter
+
+    Tracer tracer
+
+    void setup() {
+        reporter = new InMemoryReporter()
+        context = ApplicationContext.builder([
+                'tracing.jaeger.enabled'            : true,
+                'tracing.jaeger.sampler.probability': 1
+        ]).singletons(reporter).start()
+        tracer = context.getBean(Tracer)
+    }
+
+    void 'client span is finished when subscription is cancelled'() {
+        given:
+        def filter = new OpenTracingClientFilter(tracer, ConversionService.SHARED, null)
+        def publisher = filter.doFilter(HttpRequest.GET('/cancel-client'), { request ->
+            Mono.never()
+        } as ClientFilterChain)
+
+        when:
+        def subscription = Mono.from(publisher).subscribe()
+        subscription.dispose()
+
+        then:
+        new PollingConditions().eventually {
+            reporter.spans.size() == 1
+
+            JaegerSpan span = reporter.spans[0]
+            span.operationName == 'GET /cancel-client'
+            span.tags['http.client'] == true
+            span.tags['span.kind'] == 'client'
+            span.tags['http.path'] == '/cancel-client'
+            tracer.activeSpan() == null
+        }
+    }
+
+    void 'server span is finished when subscription is cancelled'() {
+        given:
+        def filter = new OpenTracingServerFilter(tracer, ConversionService.SHARED, null)
+        def publisher = filter.doFilter(HttpRequest.GET('/cancel-server'), { request ->
+            Mono.never()
+        } as ServerFilterChain)
+
+        when:
+        def subscription = Mono.from(publisher).subscribe()
+        subscription.dispose()
+
+        then:
+        new PollingConditions().eventually {
+            reporter.spans.size() == 1
+
+            JaegerSpan span = reporter.spans[0]
+            span.operationName == 'GET /cancel-server'
+            span.tags['http.server'] == true
+            span.tags['span.kind'] == 'server'
+            span.tags['http.path'] == '/cancel-server'
+            tracer.activeSpan() == null
+        }
+    }
+}

--- a/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilterSpec.groovy
+++ b/tracing-opentracing/src/test/groovy/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilterSpec.groovy
@@ -50,13 +50,9 @@ class OpenTracingServerFilterSpec extends Specification {
         request.getAttribute(TraceRequestAttributes.CURRENT_SPAN, Span).orElseThrow().is(createdSpan)
     }
 
-    void 'falls back to active span when request has no tracing headers'() {
+    void 'starts a root span when request has no tracing headers'() {
         given:
-        SpanContext activeSpanContext = Stub()
         SpanContext createdSpanContext = Stub()
-        Span currentSpan = Stub() {
-            context() >> activeSpanContext
-        }
         Scope scope = Mock()
         Span createdSpan = Mock() {
             2 * context() >> createdSpanContext
@@ -64,8 +60,8 @@ class OpenTracingServerFilterSpec extends Specification {
         Tracer.SpanBuilder spanBuilder = Mock()
         Tracer tracer = Mock() {
             1 * extract(HTTP_HEADERS, _) >> null
-            1 * activeSpan() >> currentSpan
             1 * buildSpan('GET /traced/hello') >> spanBuilder
+            0 * activeSpan()
         }
         OpenTracingServerFilter filter = newFilter(tracer)
         HttpRequest<?> request = HttpRequest.GET('/traced/hello')
@@ -74,7 +70,8 @@ class OpenTracingServerFilterSpec extends Specification {
         Mono.from(filter.doFilter(request, okChain())).block()
 
         then:
-        1 * spanBuilder.asChildOf(activeSpanContext) >> spanBuilder
+        0 * spanBuilder.asChildOf(_)
+        1 * spanBuilder.ignoreActiveSpan() >> spanBuilder
         1 * spanBuilder.withTag('http.method', 'GET') >> spanBuilder
         1 * spanBuilder.withTag('http.path', '/traced/hello') >> spanBuilder
         1 * spanBuilder.start() >> createdSpan


### PR DESCRIPTION
## Summary
- propagate OpenTracing HTTP client and server scopes around reactive subscriptions so Netty logging sees the current trace id
- avoid restoring out-of-order OpenTracing scopes that would reinstall stale Jaeger MDC values
- cover the regression with a Jaeger spec that verifies nested reactive client Netty logs use distinct request trace ids
- centralize the remaining propagated context compatibility call in the shared OpenTracing HTTP filter base class

## Verification
- `./gradlew projects --quiet`
- `./gradlew :micronaut-tracing-jaeger:test --tests io.micronaut.tracing.jaeger.HttpTracingSpec`
- `./gradlew :micronaut-tracing-opentracing:check :micronaut-tracing-jaeger:check`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/279
