### PR TITLE
Fix missing HTTP server spans after Span.makeCurrent

### DIFF
--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -113,7 +113,7 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
         return PropagatedContext.getOrEmpty()
             .find(OpenTelemetryPropagationContext.class)
             .map(OpenTelemetryPropagationContext::context)
-            .orElseGet(Context::root);
+            .orElseGet(Context::current);
     }
 
     private void onError(HttpRequest<?> request, Context context,

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -84,7 +84,7 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
 
         request.setAttribute(APPLIED, true);
 
-        Context parentContext = Context.current();
+        Context parentContext = parentContext();
         if (!instrumenter.shouldStart(parentContext, request)) {
             return chain.proceed(request);
         }
@@ -109,6 +109,13 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
                 .doOnError(throwable -> onError(request, context, null, throwable))
                 .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
         }
+    }
+
+    private static Context parentContext() {
+        return PropagatedContext.getOrEmpty()
+            .find(OpenTelemetryPropagationContext.class)
+            .map(OpenTelemetryPropagationContext::context)
+            .orElseGet(Context::root);
     }
 
     private void onError(HttpRequest<?> request, Context context,

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -90,12 +90,10 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
         }
 
         Context context = instrumenter.start(parentContext, request);
-
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new OpenTelemetryPropagationContext(context))
-            .propagate()) {
-
-            var propagatedContext = PropagatedContext.get();
+        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
+            .plus(new OpenTelemetryPropagationContext(context));
+        return propagatedContext.propagate(() -> {
+            PropagatedContext currentContext = PropagatedContext.get();
             return Mono.from(chain.proceed(request))
                 .doOnNext(mutableHttpResponse -> mutableHttpResponse.getAttribute(HttpAttributes.EXCEPTION, Exception.class)
                     .ifPresentOrElse(
@@ -107,8 +105,8 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
                             }
                         }))
                 .doOnError(throwable -> onError(request, context, null, throwable))
-                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
-        }
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, currentContext));
+        });
     }
 
     private static Context parentContext() {

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -29,6 +29,7 @@ import io.micronaut.tracing.annotation.SpanTag
 import io.micronaut.tracing.opentelemetry.utils.OpenTelemetryReactorPropagation
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
@@ -485,23 +486,30 @@ class OpenTelemetryHttpSpec extends Specification {
 
         and:
         conditions.eventually {
-            def serverSpanCount = exporter.finishedSpanItems.count {
-                it.kind == SpanKind.SERVER
-            }
-            def requestServerSpanCount = exporter.finishedSpanItems.count {
-                it.kind == SpanKind.SERVER && it.name == 'GET /propagate/makeCurrent'
-            }
-            def childSpanCount = exporter.finishedSpanItems.count {
-                it.kind == SpanKind.INTERNAL && it.name == 'findAllBooks'
-            }
-            def testSpanCount = exporter.finishedSpanItems.count {
+            def testSpans = exporter.finishedSpanItems.findAll {
                 it.kind == SpanKind.INTERNAL && it.name == 'test'
             }
+            def serverSpans = exporter.finishedSpanItems.findAll {
+                it.kind == SpanKind.SERVER && it.name == 'GET /propagate/makeCurrent'
+            }
+            def childSpans = exporter.finishedSpanItems.findAll {
+                it.kind == SpanKind.INTERNAL && it.name == 'findAllBooks'
+            }
 
-            assert serverSpanCount == 2
-            assert requestServerSpanCount == 2
-            assert childSpanCount == 2
-            assert testSpanCount == 2
+            assert testSpans.size() == 2
+            assert serverSpans.size() == 2
+            assert childSpans.size() == 2
+            assert serverSpans.every { it.parentSpanId == SpanId.getInvalid() }
+            assert serverSpans.every { serverSpan ->
+                childSpans.any { childSpan ->
+                    childSpan.traceId == serverSpan.traceId && childSpan.parentSpanId == serverSpan.spanId
+                }
+            }
+            assert childSpans.every { childSpan ->
+                serverSpans.any { serverSpan ->
+                    childSpan.traceId == serverSpan.traceId && childSpan.parentSpanId == serverSpan.spanId
+                }
+            }
             hasHttpSemanticAttributes(HttpStatus.OK)
         }
 

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -624,12 +624,17 @@ class OpenTelemetryHttpSpec extends Specification {
         @Get('/makeCurrent')
         Mono<String> makeCurrent() {
             def childSpan = tracer.spanBuilder('findAllBooks').startSpan()
-            def childScope = childSpan.makeCurrent()
 
             return Mono.delay(Duration.ofMillis(0))
-                .map { 'ok' }
+                .map {
+                    def childScope = childSpan.makeCurrent()
+                    try {
+                        return 'ok'
+                    } finally {
+                        childScope.close()
+                    }
+                }
                 .doFinally {
-                    childScope.close()
                     childSpan.end()
                 }
         }

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -31,6 +31,7 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.instrumentation.annotations.SpanAttribute
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
@@ -47,6 +48,7 @@ import spock.lang.AutoCleanup
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import io.micronaut.scheduling.TaskExecutors
@@ -463,6 +465,50 @@ class OpenTelemetryHttpSpec extends Specification {
         exporter.reset()
     }
 
+    void 'makeCurrent across reactor boundary does not suppress following server spans'() {
+        def tracer = context.getBean(Tracer)
+
+        when:
+        def responses = (1..2).collect {
+            def testSpan = tracer.spanBuilder('test').startSpan()
+            def currentSpan = testSpan.makeCurrent()
+            try {
+                httpClient.toBlocking().exchange('/propagate/makeCurrent', String)
+            } finally {
+                currentSpan.close()
+                testSpan.end()
+            }
+        }
+
+        then:
+        responses.every { it.body() == 'ok' }
+
+        and:
+        conditions.eventually {
+            def serverSpanCount = exporter.finishedSpanItems.count {
+                it.kind == SpanKind.SERVER
+            }
+            def requestServerSpanCount = exporter.finishedSpanItems.count {
+                it.kind == SpanKind.SERVER && it.name == 'GET /propagate/makeCurrent'
+            }
+            def childSpanCount = exporter.finishedSpanItems.count {
+                it.kind == SpanKind.INTERNAL && it.name == 'findAllBooks'
+            }
+            def testSpanCount = exporter.finishedSpanItems.count {
+                it.kind == SpanKind.INTERNAL && it.name == 'test'
+            }
+
+            assert serverSpanCount == 2
+            assert requestServerSpanCount == 2
+            assert childSpanCount == 2
+            assert testSpanCount == 2
+            hasHttpSemanticAttributes(HttpStatus.OK)
+        }
+
+        cleanup:
+        exporter.reset()
+    }
+
     @Introspected
     static class SomeBody {
     }
@@ -555,6 +601,9 @@ class OpenTelemetryHttpSpec extends Specification {
     static class ContextPropagateController {
 
         @Inject
+        Tracer tracer
+
+        @Inject
         PropagateClient propagateClient
 
         @Get('/hello/{name}')
@@ -570,6 +619,19 @@ class OpenTelemetryHttpSpec extends Specification {
                 int size = ctx.size()
                 return Mono.just("contains ${ServerRequestContext.KEY}: $hasKey")
             }) as Mono<String>
+        }
+
+        @Get('/makeCurrent')
+        Mono<String> makeCurrent() {
+            def childSpan = tracer.spanBuilder('findAllBooks').startSpan()
+            def childScope = childSpan.makeCurrent()
+
+            return Mono.delay(Duration.ofMillis(0))
+                .map { 'ok' }
+                .doFinally {
+                    childScope.close()
+                    childSpan.end()
+                }
         }
 
         @Get('/nestedReactive/{name}')


### PR DESCRIPTION
## Summary
- use the propagated OpenTelemetry context as the parent when deciding whether to start server spans
- fall back to the current OpenTelemetry context when no Micronaut propagated context is available
- add regression coverage for `Span.makeCurrent()` across a Reactor boundary

## Verification
- `./gradlew :micronaut-tracing-opentelemetry-http:test --tests io.micronaut.tracing.opentelemetry.instrument.http.OpenTelemetryHttpSpec -q -x japiCmp -x checkVersionCatalogCompatibility`

Resolves #475
