### PR TITLE
Fix spans with pre-registered GlobalOpenTelemetry

### DIFF
--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.trace.IdGenerator;
@@ -75,6 +76,11 @@ public class DefaultOpenTelemetryFactory {
                                                  @Nullable Sampler sampler,
                                                  Collection<OpenTelemetryBuilderCustomizer> builderCustomizers) {
 
+        OpenTelemetry existingGlobalOpenTelemetry = existingGlobalOpenTelemetry();
+        if (existingGlobalOpenTelemetry != null) {
+            return existingGlobalOpenTelemetry;
+        }
+
         Map<String, String> otel = otelConfig.entrySet().stream().collect(Collectors.toMap(
             e -> "otel." + e.getKey(),
             Map.Entry::getValue
@@ -87,7 +93,7 @@ public class DefaultOpenTelemetryFactory {
 
         AutoConfiguredOpenTelemetrySdkBuilder sdk = AutoConfiguredOpenTelemetrySdk.builder();
 
-        if (Boolean.parseBoolean(otel.getOrDefault(REGISTER_GLOBAL, StringUtils.FALSE))) {
+        if (Boolean.parseBoolean(otel.getOrDefault(REGISTER_GLOBAL, StringUtils.FALSE)) && !GlobalOpenTelemetry.isSet()) {
             sdk.setResultAsGlobal();
         }
 
@@ -115,6 +121,16 @@ public class DefaultOpenTelemetryFactory {
         }
 
         return sdk.build().getOpenTelemetrySdk();
+    }
+
+    @Nullable
+    private OpenTelemetry existingGlobalOpenTelemetry() {
+        if (!GlobalOpenTelemetry.isSet()) {
+            return null;
+        }
+
+        OpenTelemetry globalOpenTelemetry = GlobalOpenTelemetry.get();
+        return globalOpenTelemetry.getTracerProvider() == TracerProvider.noop() ? null : globalOpenTelemetry;
     }
 
     /**

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.tracing.opentelemetry
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.tracing.annotation.NewSpan
+import io.micronaut.tracing.annotation.SpanTag
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.TracerProvider
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+class DefaultOpenTelemetryFactorySpec extends Specification {
+
+    private static final AttributeKey<String> VALUE = AttributeKey.stringKey("value")
+
+    ApplicationContext context
+    OpenTelemetrySdk globalOpenTelemetry
+
+    def cleanup() {
+        context?.close()
+        globalOpenTelemetry?.close()
+        GlobalOpenTelemetry.resetForTest()
+    }
+
+    void "uses pre-registered GlobalOpenTelemetry for Micronaut spans"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        globalOpenTelemetry = OpenTelemetrySdk.builder()
+            .setTracerProvider(SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build())
+            .buildAndRegisterGlobal()
+
+        when:
+        context = ApplicationContext.run([
+            'micronaut.application.name': 'test-app',
+            'otel.register.global'      : 'true',
+            'spec.name'                 : 'DefaultOpenTelemetryFactorySpec',
+        ], Environment.TEST)
+
+        def result = context.getBean(TestService).invoke('test-value')
+
+        then:
+        result == 'test-value'
+        context.getBean(OpenTelemetry).is(GlobalOpenTelemetry.get())
+        exporter.finishedSpanItems.size() == 1
+        exporter.finishedSpanItems[0].name.contains('#invoke')
+        exporter.finishedSpanItems[0].attributes.get(VALUE) == 'test-value'
+    }
+
+    void "builds local OpenTelemetry when the global is initialized to noop"() {
+        given:
+        OpenTelemetry noopGlobal = GlobalOpenTelemetry.get()
+
+        when:
+        context = ApplicationContext.run([
+            'otel.register.global': 'true'
+        ], Environment.TEST)
+
+        then:
+        context.getBean(OpenTelemetry) != noopGlobal
+        context.getBean(OpenTelemetry).tracerProvider != TracerProvider.noop()
+    }
+
+    @Requires(property = "spec.name", value = "DefaultOpenTelemetryFactorySpec")
+    @Singleton
+    static class TestService {
+
+        @NewSpan("invoke")
+        String invoke(@SpanTag("value") String value) {
+            return value
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- reuse a pre-registered non-noop GlobalOpenTelemetry instance instead of creating a second SDK
- avoid reflective access to OpenTelemetry internals by using GlobalOpenTelemetry.isSet()
- add regression coverage for Micronaut spans with a registered global instance and for noop global initialization

## Verification
- ./gradlew :micronaut-tracing-opentelemetry:test --tests io.micronaut.tracing.opentelemetry.DefaultOpenTelemetryFactorySpec

Resolves #467