### PR TITLE
Document the 4.5.0 OpenTelemetry annotation break

### DIFF
--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -2,7 +2,10 @@ This section will document breaking changes that may happen during milestone or 
 
 == Micronaut Tracing 4.5.0 breaking changes
 
-In version `1.19.0` of OpenTelemetry annotations have moved from `io.opentelemetry.extension.annotations` to `io.opentelemetry.instrumentation.annotations`. If you want to continue to use them, you have to update package name.
+Micronaut Tracing `4.5.0` upgrades the OpenTelemetry annotation support to OpenTelemetry Instrumentation `1.19.0`.
+That release moved `@WithSpan` and `@SpanAttribute` from `io.opentelemetry.extension.annotations` to `io.opentelemetry.instrumentation.annotations`.
+
+If your application uses `micronaut-tracing-opentelemetry-annotation` and imports the old package, update those imports to the new package before upgrading to Micronaut Tracing `4.5.0` or newer.
 
 == Micronaut Tracing 5.0.0-M2 breaking changes
 
@@ -28,4 +31,3 @@ The Open Telemetry updates required updating the following Zipkin dependencies t
 The only change due to the above dependency updates that might affect end user code is that the `errorParser` property has been removed from `io.micronaut.tracing.brave.BraveTracerConfiguration` as the `brave.ErrorParser` type no longer exists.
 
 The `io.micronaut.tracing.zipkin.http.client.HttpClientSender` class is now deprecated as it implements a deprecated Zipkin API. This class will be replaced with an implementation based on the Zipkin 3 APIs in a future release.
-

--- a/src/main/docs/guide/opentelemetry/annotations.adoc
+++ b/src/main/docs/guide/opentelemetry/annotations.adoc
@@ -1,5 +1,7 @@
 The pkg:tracing.opentelemetry.processing[] package contains transformers and mappers that enables usage of Open Telemetry annotations.
 
+NOTE: Since Micronaut Tracing `4.5.0`, OpenTelemetry's `@WithSpan` and `@SpanAttribute` annotations must be imported from `io.opentelemetry.instrumentation.annotations`. Older applications that still import `io.opentelemetry.extension.annotations` need to update those imports when upgrading.
+
 To enable Open telemetry annotations you have to add next annotation processor in your dependency block:
 dependency:micronaut-tracing-opentelemetry-annotation[scope="annotationProcessor", version="{version}", groupId="io.micronaut.tracing"]
 


### PR DESCRIPTION
## Summary
- document the OpenTelemetry annotation package migration introduced in Micronaut Tracing 4.5.0
- add the upgrade note to the OpenTelemetry annotations guide as well as the breaking changes page

## Verification
- `./gradlew spotlessCheck -q`
- `./gradlew assembleDocs -q`

Resolves #288