### PR TITLE
Add OpenTelemetry RabbitMQ tracing module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,7 +104,6 @@ opentelemetry-instrumentation-jdbc = { module = 'io.opentelemetry.instrumentatio
 opentelemetry-instrumentation-r2dbc = { module = 'io.opentelemetry.instrumentation:opentelemetry-r2dbc-1.0' }
 opentelemetry-aws-sdk = { module = 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2' }
 testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka"}
-testcontainers-rabbitmq = { module = "org.testcontainers:rabbitmq", version.ref = "managed-testcontainers"}
 awssdk-core = { module = 'software.amazon.awssdk:sdk-core' }
 
 # BOMs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ micronaut-rxjava3 = "4.0.0-RC1"
 micronaut-serde = "3.0.0-RC2"
 micronaut-sql = "7.0.0-RC1"
 micronaut-kafka = '6.0.0-M2'
+micronaut-rabbitmq = '5.0.0-M1'
 micronaut-gradle-plugin = "5.0.0-M1"
 micronaut-r2dbc = "7.0.1-RC1"
 [libraries]
@@ -60,6 +61,7 @@ micronaut-serde = { module = 'io.micronaut.serde:micronaut-serde-bom', version.r
 micronaut-sql = { module = 'io.micronaut.sql:micronaut-sql-bom', version.ref = 'micronaut-sql' }
 micronaut-kafka = { module = 'io.micronaut.kafka:micronaut-kafka-bom', version.ref = 'micronaut-kafka'}
 micronaut-r2dbc = { module = 'io.micronaut.r2dbc:micronaut-r2dbc-bom', version.ref = 'micronaut-r2dbc'}
+micronaut-rabbitmq = { module = 'io.micronaut.rabbitmq:micronaut-rabbitmq', version.ref = 'micronaut-rabbitmq'}
 
 brave-instrumentation-http = { module = 'io.zipkin.brave:brave-instrumentation-http' }
 brave-opentracing = { module = 'io.opentracing.brave:brave-opentracing', version.ref = 'managed-brave-opentracing' }
@@ -102,6 +104,7 @@ opentelemetry-instrumentation-jdbc = { module = 'io.opentelemetry.instrumentatio
 opentelemetry-instrumentation-r2dbc = { module = 'io.opentelemetry.instrumentation:opentelemetry-r2dbc-1.0' }
 opentelemetry-aws-sdk = { module = 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2' }
 testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka"}
+testcontainers-rabbitmq = { module = "org.testcontainers:rabbitmq", version.ref = "managed-testcontainers"}
 awssdk-core = { module = 'software.amazon.awssdk:sdk-core' }
 
 # BOMs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ managed-zipkin-reporter = '3.5.3'
 
 
 managed-jaeger = '1.8.1'
+managed-libthrift = '0.23.0'
 managed-opentracing = '0.33.0'
 managed-opentracing-grpc = '0.2.3'
 managed-brave-opentracing = '1.0.1'
@@ -70,6 +71,7 @@ grpc-stub = { module = 'io.grpc:grpc-stub', version.ref = 'grpc' }
 gson = { module = 'com.google.code.gson:gson', version.ref = 'gson' }
 okio = { module = 'com.squareup.okio:okio', version.ref = 'okio' }
 jaeger = { module = 'io.jaegertracing:jaeger-thrift', version.ref = 'managed-jaeger' }
+libthrift = { module = 'org.apache.thrift:libthrift', version.ref = 'managed-libthrift' }
 javax-annotation = { module = 'javax.annotation:javax.annotation-api', version.ref = 'javax-annotation' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version = '' }
 protobuf-java = { module = 'com.google.protobuf:protobuf-java', version.ref = 'protobuf' }

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,7 @@ include 'tracing-opentelemetry-http'
 include 'tracing-opentelemetry-jdbc'
 include 'tracing-opentelemetry-kafka'
 include 'tracing-opentelemetry-r2dbc'
+include 'tracing-opentelemetry-rabbitmq'
 include 'tracing-opentelemetry-zipkin-exporter'
 
 // OpenTracing

--- a/src/main/docs/guide/opentelemetry/rabbitmq.adoc
+++ b/src/main/docs/guide/opentelemetry/rabbitmq.adoc
@@ -2,10 +2,7 @@ RabbitMQ / AMQP tracing is supported by the `micronaut-tracing-opentelemetry-rab
 
 Add the dependency to enable OpenTelemetry tracing for Micronaut RabbitMQ publishers and listeners.
 
-[source,groovy]
-----
-implementation("io.micronaut.tracing:micronaut-tracing-opentelemetry-rabbitmq")
-----
+dependency:micronaut-tracing-opentelemetry-rabbitmq[scope="implementation", groupId="io.micronaut.tracing"]
 
 The module creates producer spans for `@RabbitClient` publications, injects the active trace context into AMQP headers, and creates consumer spans for `@RabbitListener` deliveries after extracting that propagated context.
 
@@ -17,4 +14,15 @@ otel:
   instrumentation:
     rabbitmq:
       enabled: false
+----
+
+Wrapper-based instrumentation for Micronaut RabbitMQ publishers and channel pools is enabled by default.
+To keep the RabbitMQ telemetry bean available but disable wrapper registration, set:
+
+[configuration]
+----
+otel:
+  instrumentation:
+    rabbitmq:
+      wrapper: false
 ----

--- a/src/main/docs/guide/opentelemetry/rabbitmq.adoc
+++ b/src/main/docs/guide/opentelemetry/rabbitmq.adoc
@@ -1,0 +1,20 @@
+RabbitMQ / AMQP tracing is supported by the `micronaut-tracing-opentelemetry-rabbitmq` module.
+
+Add the dependency to enable OpenTelemetry tracing for Micronaut RabbitMQ publishers and listeners.
+
+[source,groovy]
+----
+implementation("io.micronaut.tracing:micronaut-tracing-opentelemetry-rabbitmq")
+----
+
+The module creates producer spans for `@RabbitClient` publications, injects the active trace context into AMQP headers, and creates consumer spans for `@RabbitListener` deliveries after extracting that propagated context.
+
+Instrumentation is enabled by default and can be disabled with:
+
+[configuration]
+----
+otel:
+  instrumentation:
+    rabbitmq:
+      enabled: false
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -16,6 +16,7 @@ opentelemetry:
   jdbc: JDBC
   r2dbc: R2DBC
   kafka: Kafka
+  rabbitmq: RabbitMQ / AMQP
   awsSdkInstrumentation: AWS SDK Instrumentation
   awsResourceDetectors: AWS Resource Detectors
   opentelemetryGuides: OpenTelemetry Guides

--- a/tracing-jaeger/build.gradle
+++ b/tracing-jaeger/build.gradle
@@ -15,6 +15,10 @@ dependencies {
     // okio is a transitive dependency of io.jaegertracing:jaeger-thrift via okhttp3
     // https://osv.dev/GHSA-w33c-445m-f8w7
     implementation(libs.okio)
+    // libthrift is a transitive dependency of io.jaegertracing:jaeger-thrift.
+    // jaeger-thrift 1.8.1 is the latest release, so use a current libthrift version to avoid GHSA-7pwc-h2j2-rjgj.
+    // https://osv.dev/GHSA-7pwc-h2j2-rjgj
+    implementation(libs.libthrift)
     testImplementation mnReactor.micronaut.reactor
     testImplementation mn.micronaut.http.server.netty
     testRuntimeOnly mnSerde.micronaut.serde.jackson

--- a/tracing-opentelemetry-rabbitmq/build.gradle
+++ b/tracing-opentelemetry-rabbitmq/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'io.micronaut.build.internal.tracing-module'
+}
+
+dependencies {
+    api platform(libs.boms.opentelemetry)
+    api platform(libs.boms.opentelemetry.alpha)
+    api projects.micronautTracingOpentelemetry
+    api libs.opentelemetry.api
+    api libs.micronaut.rabbitmq
+    implementation mnReactor.micronaut.reactor
+
+    testImplementation mnSerde.micronaut.serde.jackson
+    testImplementation libs.opentelemetry.sdk
+    testImplementation libs.opentelemetry.sdk.testing
+    testImplementation(platform(mnTest.boms.testcontainers))
+    testImplementation "org.testcontainers:testcontainers"
+}
+
+micronautBuild {
+    binaryCompatibility {
+        def dash = version.indexOf('-')
+        def v = dash > 0 ? version.substring(0, dash) : version
+        def (major, minor, patch) = v.split('[.]').collect { it.toInteger() }
+        enabled = major > 8 || (major == 8 && minor > 0) || (major == 8 && minor == 0 && patch > 0)
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQChannelPoolTracingInstrumentation.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQChannelPoolTracingInstrumentation.java
@@ -25,7 +25,7 @@ import jakarta.inject.Singleton;
 /**
  * Wraps RabbitMQ channel pools with tracing-aware channels.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".wrapper", notEquals = StringUtils.FALSE)
 @Singleton

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQChannelPoolTracingInstrumentation.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQChannelPoolTracingInstrumentation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.rabbitmq.connect.ChannelPool;
+import jakarta.inject.Singleton;
+
+/**
+ * Wraps RabbitMQ channel pools with tracing-aware channels.
+ *
+ * @since 5.1.0
+ */
+@Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".wrapper", notEquals = StringUtils.FALSE)
+@Singleton
+public class RabbitMQChannelPoolTracingInstrumentation implements BeanCreatedEventListener<ChannelPool> {
+
+    private final RabbitMQTelemetry rabbitMQTelemetry;
+
+    public RabbitMQChannelPoolTracingInstrumentation(RabbitMQTelemetry rabbitMQTelemetry) {
+        this.rabbitMQTelemetry = rabbitMQTelemetry;
+    }
+
+    @Override
+    public ChannelPool onCreated(BeanCreatedEvent<ChannelPool> event) {
+        ChannelPool bean = event.getBean();
+        if (bean instanceof TracingChannelPool) {
+            return bean;
+        }
+        return rabbitMQTelemetry.wrap(bean);
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
@@ -15,12 +15,16 @@
  */
 package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
 
+import com.rabbitmq.client.LongString;
 import io.opentelemetry.context.propagation.TextMapGetter;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 
 final class RabbitMQHeadersGetter implements TextMapGetter<Map<String, Object>> {
+
+    static final int MAX_PROPAGATION_HEADER_VALUE_BYTES = 8192;
 
     @Override
     public Iterable<String> keys(Map<String, Object> carrier) {
@@ -33,6 +37,21 @@ final class RabbitMQHeadersGetter implements TextMapGetter<Map<String, Object>> 
             return null;
         }
         Object value = carrier.get(key);
-        return value == null ? null : value.toString();
+        if (value instanceof String string) {
+            return string.length() <= MAX_PROPAGATION_HEADER_VALUE_BYTES ? string : null;
+        }
+        if (value instanceof LongString longString) {
+            if (longString.length() > MAX_PROPAGATION_HEADER_VALUE_BYTES) {
+                return null;
+            }
+            return new String(longString.getBytes(), StandardCharsets.UTF_8);
+        }
+        if (value instanceof byte[] bytes) {
+            if (bytes.length > MAX_PROPAGATION_HEADER_VALUE_BYTES) {
+                return null;
+            }
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return null;
     }
 }

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.opentelemetry.context.propagation.TextMapGetter;
+
+import java.util.Collections;
+import java.util.Map;
+
+enum RabbitMQHeadersGetter implements TextMapGetter<Map<String, Object>> {
+    INSTANCE;
+
+    @Override
+    public Iterable<String> keys(Map<String, Object> carrier) {
+        return carrier == null ? Collections.emptyList() : carrier.keySet();
+    }
+
+    @Override
+    public String get(Map<String, Object> carrier, String key) {
+        if (carrier == null) {
+            return null;
+        }
+        Object value = carrier.get(key);
+        return value == null ? null : value.toString();
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
@@ -17,15 +17,19 @@ package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
 
-import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
-enum RabbitMQHeadersGetter implements TextMapGetter<Map<String, Object>> {
-    INSTANCE;
+final class RabbitMQHeadersGetter implements TextMapGetter<Map<String, Object>> {
+
+    static final RabbitMQHeadersGetter INSTANCE = new RabbitMQHeadersGetter();
+
+    private RabbitMQHeadersGetter() {
+    }
 
     @Override
     public Iterable<String> keys(Map<String, Object> carrier) {
-        return carrier == null ? Collections.emptyList() : carrier.keySet();
+        return carrier == null ? Set.of() : carrier.keySet();
     }
 
     @Override

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersGetter.java
@@ -22,11 +22,6 @@ import java.util.Set;
 
 final class RabbitMQHeadersGetter implements TextMapGetter<Map<String, Object>> {
 
-    static final RabbitMQHeadersGetter INSTANCE = new RabbitMQHeadersGetter();
-
-    private RabbitMQHeadersGetter() {
-    }
-
     @Override
     public Iterable<String> keys(Map<String, Object> carrier) {
         return carrier == null ? Set.of() : carrier.keySet();

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSetter.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSetter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+import java.util.Map;
+
+enum RabbitMQHeadersSetter implements TextMapSetter<Map<String, Object>> {
+    INSTANCE;
+
+    @Override
+    public void set(Map<String, Object> carrier, String key, String value) {
+        if (carrier != null) {
+            carrier.put(key, value);
+        }
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSetter.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSetter.java
@@ -21,11 +21,6 @@ import java.util.Map;
 
 final class RabbitMQHeadersSetter implements TextMapSetter<Map<String, Object>> {
 
-    static final RabbitMQHeadersSetter INSTANCE = new RabbitMQHeadersSetter();
-
-    private RabbitMQHeadersSetter() {
-    }
-
     @Override
     public void set(Map<String, Object> carrier, String key, String value) {
         if (carrier != null) {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSetter.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSetter.java
@@ -19,8 +19,12 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 
 import java.util.Map;
 
-enum RabbitMQHeadersSetter implements TextMapSetter<Map<String, Object>> {
-    INSTANCE;
+final class RabbitMQHeadersSetter implements TextMapSetter<Map<String, Object>> {
+
+    static final RabbitMQHeadersSetter INSTANCE = new RabbitMQHeadersSetter();
+
+    private RabbitMQHeadersSetter() {
+    }
 
     @Override
     public void set(Map<String, Object> carrier, String key, String value) {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQReactivePublisherTracingInstrumentation.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQReactivePublisherTracingInstrumentation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.rabbitmq.reactive.ReactivePublisher;
+import jakarta.inject.Singleton;
+
+/**
+ * Wraps reactive RabbitMQ publishers with tracing.
+ *
+ * @since 5.1.0
+ */
+@Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".wrapper", notEquals = StringUtils.FALSE)
+@Singleton
+public class RabbitMQReactivePublisherTracingInstrumentation implements BeanCreatedEventListener<ReactivePublisher> {
+
+    private final RabbitMQTelemetry rabbitMQTelemetry;
+
+    public RabbitMQReactivePublisherTracingInstrumentation(RabbitMQTelemetry rabbitMQTelemetry) {
+        this.rabbitMQTelemetry = rabbitMQTelemetry;
+    }
+
+    @Override
+    public ReactivePublisher onCreated(BeanCreatedEvent<ReactivePublisher> event) {
+        ReactivePublisher bean = event.getBean();
+        if (bean instanceof TracingReactivePublisher) {
+            return bean;
+        }
+        return rabbitMQTelemetry.wrap(bean);
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQReactivePublisherTracingInstrumentation.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQReactivePublisherTracingInstrumentation.java
@@ -25,7 +25,7 @@ import jakarta.inject.Singleton;
 /**
  * Wraps reactive RabbitMQ publishers with tracing.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".wrapper", notEquals = StringUtils.FALSE)
 @Singleton

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
@@ -78,8 +78,8 @@ public final class RabbitMQTelemetry {
     }
 
     Channel wrap(Channel channel) {
-        if (channel instanceof TracingChannel tracingChannel) {
-            return tracingChannel.getDelegate();
+        if (channel instanceof TracingChannel) {
+            return channel;
         }
         return (Channel) Proxy.newProxyInstance(
             Channel.class.getClassLoader(),
@@ -111,7 +111,7 @@ public final class RabbitMQTelemetry {
     }
 
     void handleDelivery(Consumer consumer, String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
-        Context parentContext = propagator.extract(Context.root(), properties == null ? null : properties.getHeaders(), RabbitMQHeadersGetter.INSTANCE);
+        Context parentContext = propagator.extract(Context.root(), properties == null ? null : properties.getHeaders(), new RabbitMQHeadersGetter());
         Span span = tracer.spanBuilder("rabbitmq process")
             .setParent(parentContext)
             .setSpanKind(SpanKind.CONSUMER)
@@ -155,7 +155,7 @@ public final class RabbitMQTelemetry {
         Map<String, Object> headers = publishState.getProperties().getHeaders() == null
             ? new HashMap<>()
             : new HashMap<>(publishState.getProperties().getHeaders());
-        propagator.inject(context, headers, RabbitMQHeadersSetter.INSTANCE);
+        propagator.inject(context, headers, new RabbitMQHeadersSetter());
         AMQP.BasicProperties properties = publishState.getProperties().builder()
             .headers(headers)
             .build();

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
@@ -119,15 +119,9 @@ public final class RabbitMQTelemetry {
         setSpanAttributes(span, "process", envelope == null ? "" : envelope.getExchange(), envelope == null ? "" : envelope.getRoutingKey());
         try (Scope ignored = parentContext.with(span).makeCurrent()) {
             consumer.handleDelivery(consumerTag, envelope, properties, body);
-        } catch (Throwable e) {
+        } catch (IOException | RuntimeException e) {
             markFailed(span, e);
-            if (e instanceof IOException ioException) {
-                throw ioException;
-            }
-            if (e instanceof RuntimeException runtimeException) {
-                throw runtimeException;
-            }
-            throw new IOException("Failed to process RabbitMQ delivery", e);
+            throw e;
         } finally {
             span.end();
         }
@@ -150,7 +144,7 @@ public final class RabbitMQTelemetry {
             return Mono.from(publisher)
                 .doOnError(error -> markFailed(span, error))
                 .doFinally(signalType -> span.end());
-        } catch (Throwable e) {
+        } catch (RuntimeException e) {
             markFailed(span, e);
             span.end();
             throw e;

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
@@ -128,27 +128,29 @@ public final class RabbitMQTelemetry {
     }
 
     private <T> Publisher<T> tracePublisherOperation(String operation, RabbitPublishState publishState, Function<RabbitPublishState, Publisher<T>> publisherFactory) {
-        Context parentContext = Context.current();
-        Span span = tracer.spanBuilder("rabbitmq " + operation)
-            .setParent(parentContext)
-            .setSpanKind(SpanKind.PRODUCER)
-            .startSpan();
-        setSpanAttributes(span, operation, publishState.getExchange(), publishState.getRoutingKey());
-        Context context = parentContext.with(span);
-        RabbitPublishState tracedState = injectContext(context, publishState);
-        try {
-            Publisher<T> publisher;
-            try (Scope ignored = context.makeCurrent()) {
-                publisher = publisherFactory.apply(tracedState);
+        return Mono.defer(() -> {
+            Context parentContext = Context.current();
+            Span span = tracer.spanBuilder("rabbitmq " + operation)
+                .setParent(parentContext)
+                .setSpanKind(SpanKind.PRODUCER)
+                .startSpan();
+            setSpanAttributes(span, operation, publishState.getExchange(), publishState.getRoutingKey());
+            Context context = parentContext.with(span);
+            RabbitPublishState tracedState = injectContext(context, publishState);
+            try {
+                Publisher<T> publisher;
+                try (Scope ignored = context.makeCurrent()) {
+                    publisher = publisherFactory.apply(tracedState);
+                }
+                return Mono.from(publisher)
+                    .doOnError(error -> markFailed(span, error))
+                    .doFinally(signalType -> span.end());
+            } catch (RuntimeException e) {
+                markFailed(span, e);
+                span.end();
+                throw e;
             }
-            return Mono.from(publisher)
-                .doOnError(error -> markFailed(span, error))
-                .doFinally(signalType -> span.end());
-        } catch (RuntimeException e) {
-            markFailed(span, e);
-            span.end();
-            throw e;
-        }
+        });
     }
 
     private RabbitPublishState injectContext(Context context, RabbitPublishState publishState) {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
@@ -48,7 +48,7 @@ import java.util.function.Function;
 /**
  * RabbitMQ telemetry support based on bean wrappers.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Internal
 public final class RabbitMQTelemetry {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
@@ -55,8 +55,12 @@ public final class RabbitMQTelemetry {
 
     static final AttributeKey<String> MESSAGING_SYSTEM = AttributeKey.stringKey("messaging.system");
     static final AttributeKey<String> MESSAGING_OPERATION = AttributeKey.stringKey("messaging.operation");
+    static final AttributeKey<String> MESSAGING_OPERATION_NAME = AttributeKey.stringKey("messaging.operation.name");
+    static final AttributeKey<String> MESSAGING_OPERATION_TYPE = AttributeKey.stringKey("messaging.operation.type");
+    static final AttributeKey<String> ERROR_TYPE = AttributeKey.stringKey("error.type");
     static final AttributeKey<String> EXCHANGE = AttributeKey.stringKey("messaging.rabbitmq.destination.exchange");
     static final AttributeKey<String> ROUTING_KEY = AttributeKey.stringKey("messaging.rabbitmq.destination.routing_key");
+    static final AttributeKey<Long> DELIVERY_TAG = AttributeKey.longKey("messaging.rabbitmq.message.delivery_tag");
     static final AttributeKey<String> DESTINATION = AttributeKey.stringKey("messaging.destination.name");
 
     private static final String INSTRUMENTATION_NAME = "io.micronaut.tracing.rabbitmq";
@@ -117,6 +121,9 @@ public final class RabbitMQTelemetry {
             .setSpanKind(SpanKind.CONSUMER)
             .startSpan();
         setSpanAttributes(span, "process", envelope == null ? "" : envelope.getExchange(), envelope == null ? "" : envelope.getRoutingKey());
+        if (envelope != null) {
+            span.setAttribute(DELIVERY_TAG, envelope.getDeliveryTag());
+        }
         try (Scope ignored = parentContext.with(span).makeCurrent()) {
             consumer.handleDelivery(consumerTag, envelope, properties, body);
         } catch (IOException | RuntimeException e) {
@@ -173,11 +180,14 @@ public final class RabbitMQTelemetry {
     private static void setSpanAttributes(Span span, String operation, String exchange, String routingKey) {
         span.setAttribute(MESSAGING_SYSTEM, "rabbitmq");
         span.setAttribute(MESSAGING_OPERATION, operation);
+        span.setAttribute(MESSAGING_OPERATION_NAME, operation);
+        span.setAttribute(MESSAGING_OPERATION_TYPE, operationType(operation));
+        String destination = destination(exchange, routingKey);
+        if (!destination.isEmpty()) {
+            span.setAttribute(DESTINATION, destination);
+        }
         if (exchange != null && !exchange.isEmpty()) {
             span.setAttribute(EXCHANGE, exchange);
-            span.setAttribute(DESTINATION, exchange);
-        } else if (routingKey != null && !routingKey.isEmpty()) {
-            span.setAttribute(DESTINATION, routingKey);
         }
         if (routingKey != null && !routingKey.isEmpty()) {
             span.setAttribute(ROUTING_KEY, routingKey);
@@ -186,7 +196,25 @@ public final class RabbitMQTelemetry {
 
     private static void markFailed(Span span, Throwable error) {
         span.recordException(error);
+        span.setAttribute(ERROR_TYPE, error.getClass().getName());
         span.setStatus(StatusCode.ERROR);
+    }
+
+    private static String operationType(String operation) {
+        return "publish".equals(operation) ? "send" : operation;
+    }
+
+    private static String destination(String exchange, String routingKey) {
+        if (exchange != null && !exchange.isEmpty() && routingKey != null && !routingKey.isEmpty()) {
+            return exchange + ":" + routingKey;
+        }
+        if (exchange != null && !exchange.isEmpty()) {
+            return exchange;
+        }
+        if (routingKey != null && !routingKey.isEmpty()) {
+            return routingKey;
+        }
+        return "amq.default";
     }
 
     interface TracingChannel {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetry.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.rabbitmq.bind.RabbitConsumerState;
+import io.micronaut.rabbitmq.connect.ChannelPool;
+import io.micronaut.rabbitmq.reactive.RabbitPublishState;
+import io.micronaut.rabbitmq.reactive.ReactivePublisher;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * RabbitMQ telemetry support based on bean wrappers.
+ *
+ * @since 5.1.0
+ */
+@Internal
+public final class RabbitMQTelemetry {
+
+    static final AttributeKey<String> MESSAGING_SYSTEM = AttributeKey.stringKey("messaging.system");
+    static final AttributeKey<String> MESSAGING_OPERATION = AttributeKey.stringKey("messaging.operation");
+    static final AttributeKey<String> EXCHANGE = AttributeKey.stringKey("messaging.rabbitmq.destination.exchange");
+    static final AttributeKey<String> ROUTING_KEY = AttributeKey.stringKey("messaging.rabbitmq.destination.routing_key");
+    static final AttributeKey<String> DESTINATION = AttributeKey.stringKey("messaging.destination.name");
+
+    private static final String INSTRUMENTATION_NAME = "io.micronaut.tracing.rabbitmq";
+
+    private final Tracer tracer;
+    private final TextMapPropagator propagator;
+
+    RabbitMQTelemetry(OpenTelemetry openTelemetry) {
+        this.tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
+        this.propagator = openTelemetry.getPropagators().getTextMapPropagator();
+    }
+
+    ReactivePublisher wrap(ReactivePublisher reactivePublisher) {
+        return new TracingReactivePublisher(reactivePublisher, this);
+    }
+
+    ChannelPool wrap(ChannelPool channelPool) {
+        return new TracingChannelPool(channelPool, this);
+    }
+
+    Channel wrap(Channel channel) {
+        if (channel instanceof TracingChannel tracingChannel) {
+            return tracingChannel.getDelegate();
+        }
+        return (Channel) Proxy.newProxyInstance(
+            Channel.class.getClassLoader(),
+            new Class<?>[] {Channel.class, TracingChannel.class},
+            new TracingChannelInvocationHandler(channel, this)
+        );
+    }
+
+    Channel unwrap(Channel channel) {
+        if (channel instanceof TracingChannel tracingChannel) {
+            return tracingChannel.getDelegate();
+        }
+        return channel;
+    }
+
+    Consumer wrap(Consumer consumer) {
+        if (consumer instanceof TracingConsumer) {
+            return consumer;
+        }
+        return new TracingConsumer(consumer, this);
+    }
+
+    Publisher<Void> tracePublish(RabbitPublishState publishState, Function<RabbitPublishState, Publisher<Void>> publisherFactory) {
+        return tracePublisherOperation("publish", publishState, publisherFactory);
+    }
+
+    Publisher<RabbitConsumerState> tracePublishAndReply(RabbitPublishState publishState, Function<RabbitPublishState, Publisher<RabbitConsumerState>> publisherFactory) {
+        return tracePublisherOperation("publish", publishState, publisherFactory);
+    }
+
+    void handleDelivery(Consumer consumer, String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+        Context parentContext = propagator.extract(Context.root(), properties == null ? null : properties.getHeaders(), RabbitMQHeadersGetter.INSTANCE);
+        Span span = tracer.spanBuilder("rabbitmq process")
+            .setParent(parentContext)
+            .setSpanKind(SpanKind.CONSUMER)
+            .startSpan();
+        setSpanAttributes(span, "process", envelope == null ? "" : envelope.getExchange(), envelope == null ? "" : envelope.getRoutingKey());
+        try (Scope ignored = parentContext.with(span).makeCurrent()) {
+            consumer.handleDelivery(consumerTag, envelope, properties, body);
+        } catch (Throwable e) {
+            markFailed(span, e);
+            if (e instanceof IOException ioException) {
+                throw ioException;
+            }
+            if (e instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new IOException("Failed to process RabbitMQ delivery", e);
+        } finally {
+            span.end();
+        }
+    }
+
+    private <T> Publisher<T> tracePublisherOperation(String operation, RabbitPublishState publishState, Function<RabbitPublishState, Publisher<T>> publisherFactory) {
+        Context parentContext = Context.current();
+        Span span = tracer.spanBuilder("rabbitmq " + operation)
+            .setParent(parentContext)
+            .setSpanKind(SpanKind.PRODUCER)
+            .startSpan();
+        setSpanAttributes(span, operation, publishState.getExchange(), publishState.getRoutingKey());
+        Context context = parentContext.with(span);
+        RabbitPublishState tracedState = injectContext(context, publishState);
+        try {
+            Publisher<T> publisher;
+            try (Scope ignored = context.makeCurrent()) {
+                publisher = publisherFactory.apply(tracedState);
+            }
+            return Mono.from(publisher)
+                .doOnError(error -> markFailed(span, error))
+                .doFinally(signalType -> span.end());
+        } catch (Throwable e) {
+            markFailed(span, e);
+            span.end();
+            throw e;
+        }
+    }
+
+    private RabbitPublishState injectContext(Context context, RabbitPublishState publishState) {
+        Map<String, Object> headers = publishState.getProperties().getHeaders() == null
+            ? new HashMap<>()
+            : new HashMap<>(publishState.getProperties().getHeaders());
+        propagator.inject(context, headers, RabbitMQHeadersSetter.INSTANCE);
+        AMQP.BasicProperties properties = publishState.getProperties().builder()
+            .headers(headers)
+            .build();
+        return new RabbitPublishState(
+            publishState.getExchange(),
+            publishState.getRoutingKey(),
+            publishState.getMandatory(),
+            properties,
+            publishState.getBody()
+        );
+    }
+
+    private static void setSpanAttributes(Span span, String operation, String exchange, String routingKey) {
+        span.setAttribute(MESSAGING_SYSTEM, "rabbitmq");
+        span.setAttribute(MESSAGING_OPERATION, operation);
+        if (exchange != null && !exchange.isEmpty()) {
+            span.setAttribute(EXCHANGE, exchange);
+            span.setAttribute(DESTINATION, exchange);
+        } else if (routingKey != null && !routingKey.isEmpty()) {
+            span.setAttribute(DESTINATION, routingKey);
+        }
+        if (routingKey != null && !routingKey.isEmpty()) {
+            span.setAttribute(ROUTING_KEY, routingKey);
+        }
+    }
+
+    private static void markFailed(Span span, Throwable error) {
+        span.recordException(error);
+        span.setStatus(StatusCode.ERROR);
+    }
+
+    interface TracingChannel {
+        Channel getDelegate();
+    }
+
+    private static final class TracingChannelInvocationHandler implements InvocationHandler {
+
+        private final Channel channel;
+        private final RabbitMQTelemetry telemetry;
+
+        private TracingChannelInvocationHandler(Channel channel, RabbitMQTelemetry telemetry) {
+            this.channel = channel;
+            this.telemetry = telemetry;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (method.getDeclaringClass() == TracingChannel.class) {
+                return channel;
+            }
+            if (method.getDeclaringClass() == Object.class) {
+                return switch (method.getName()) {
+                    case "equals" -> proxy == args[0];
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "toString" -> "TracingChannel(" + channel + ")";
+                    default -> method.invoke(channel, args);
+                };
+            }
+            Object[] instrumentedArgs = instrumentArgs(method, args);
+            try {
+                return method.invoke(channel, instrumentedArgs);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+        }
+
+        private Object[] instrumentArgs(Method method, Object[] args) {
+            if (args == null || !"basicConsume".equals(method.getName())) {
+                return args;
+            }
+            Object[] instrumentedArgs = args.clone();
+            for (int i = 0; i < instrumentedArgs.length; i++) {
+                if (instrumentedArgs[i] instanceof Consumer consumer) {
+                    instrumentedArgs[i] = telemetry.wrap(consumer);
+                }
+            }
+            return instrumentedArgs;
+        }
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryConfiguration.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+
+/**
+ * Configuration properties for RabbitMQ telemetry.
+ *
+ * @since 5.1.0
+ */
+@Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+@ConfigurationProperties(RabbitMQTelemetryConfiguration.PREFIX)
+public class RabbitMQTelemetryConfiguration {
+
+    /**
+     * The configuration prefix.
+     */
+    public static final String PREFIX = "otel.instrumentation.rabbitmq";
+
+    private boolean wrapper = true;
+
+    /**
+     * @return Whether wrapper-based instrumentation is enabled
+     */
+    public boolean isWrapper() {
+        return wrapper;
+    }
+
+    /**
+     * @param wrapper Whether wrapper-based instrumentation is enabled
+     */
+    public void setWrapper(boolean wrapper) {
+        this.wrapper = wrapper;
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryConfiguration.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryConfiguration.java
@@ -22,7 +22,7 @@ import io.micronaut.core.util.StringUtils;
 /**
  * Configuration properties for RabbitMQ telemetry.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 @ConfigurationProperties(RabbitMQTelemetryConfiguration.PREFIX)

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryFactory.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.micronaut.context.annotation.Factory;
+import io.opentelemetry.api.OpenTelemetry;
+import jakarta.inject.Singleton;
+
+/**
+ * Factory for RabbitMQ telemetry support.
+ *
+ * @since 5.1.0
+ */
+@Factory
+public final class RabbitMQTelemetryFactory {
+
+    @Singleton
+    RabbitMQTelemetry rabbitMQTelemetry(OpenTelemetry openTelemetry) {
+        return new RabbitMQTelemetry(openTelemetry);
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryFactory.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryFactory.java
@@ -22,7 +22,7 @@ import jakarta.inject.Singleton;
 /**
  * Factory for RabbitMQ telemetry support.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Factory
 public final class RabbitMQTelemetryFactory {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPool.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPool.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 /**
  * Tracing wrapper for {@link ChannelPool}.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Internal
 final class TracingChannelPool implements ChannelPool {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPool.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPool.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.rabbitmq.connect.ChannelPool;
+
+import java.io.IOException;
+
+/**
+ * Tracing wrapper for {@link ChannelPool}.
+ *
+ * @since 5.1.0
+ */
+@Internal
+final class TracingChannelPool implements ChannelPool {
+
+    private final ChannelPool delegate;
+    private final RabbitMQTelemetry telemetry;
+
+    TracingChannelPool(ChannelPool delegate, RabbitMQTelemetry telemetry) {
+        this.delegate = delegate;
+        this.telemetry = telemetry;
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public Channel getChannel() throws IOException {
+        return telemetry.wrap(delegate.getChannel());
+    }
+
+    @Override
+    public Channel getChannelWithRecoveringDelay(int recoveryAttempts) throws IOException, InterruptedException {
+        return telemetry.wrap(delegate.getChannelWithRecoveringDelay(recoveryAttempts));
+    }
+
+    @Override
+    public boolean isTopologyRecoveryEnabled() {
+        return delegate.isTopologyRecoveryEnabled();
+    }
+
+    @Override
+    public void returnChannel(Channel channel) {
+        delegate.returnChannel(telemetry.unwrap(channel));
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingConsumer.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingConsumer.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * Tracing wrapper for {@link Consumer}.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Internal
 final class TracingConsumer implements Consumer {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingConsumer.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingConsumer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.ShutdownSignalException;
+import io.micronaut.core.annotation.Internal;
+
+import java.io.IOException;
+
+/**
+ * Tracing wrapper for {@link Consumer}.
+ *
+ * @since 5.1.0
+ */
+@Internal
+final class TracingConsumer implements Consumer {
+
+    private final Consumer delegate;
+    private final RabbitMQTelemetry telemetry;
+
+    TracingConsumer(Consumer delegate, RabbitMQTelemetry telemetry) {
+        this.delegate = delegate;
+        this.telemetry = telemetry;
+    }
+
+    @Override
+    public void handleConsumeOk(String consumerTag) {
+        delegate.handleConsumeOk(consumerTag);
+    }
+
+    @Override
+    public void handleCancelOk(String consumerTag) {
+        delegate.handleCancelOk(consumerTag);
+    }
+
+    @Override
+    public void handleCancel(String consumerTag) throws IOException {
+        delegate.handleCancel(consumerTag);
+    }
+
+    @Override
+    public void handleShutdownSignal(String consumerTag, ShutdownSignalException sig) {
+        delegate.handleShutdownSignal(consumerTag, sig);
+    }
+
+    @Override
+    public void handleRecoverOk(String consumerTag) {
+        delegate.handleRecoverOk(consumerTag);
+    }
+
+    @Override
+    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+        telemetry.handleDelivery(delegate, consumerTag, envelope, properties, body);
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisher.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisher.java
@@ -24,7 +24,7 @@ import org.reactivestreams.Publisher;
 /**
  * Tracing wrapper for {@link ReactivePublisher}.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Internal
 final class TracingReactivePublisher implements ReactivePublisher {

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisher.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisher.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.rabbitmq.bind.RabbitConsumerState;
+import io.micronaut.rabbitmq.reactive.RabbitPublishState;
+import io.micronaut.rabbitmq.reactive.ReactivePublisher;
+import org.reactivestreams.Publisher;
+
+/**
+ * Tracing wrapper for {@link ReactivePublisher}.
+ *
+ * @since 5.1.0
+ */
+@Internal
+final class TracingReactivePublisher implements ReactivePublisher {
+
+    private final ReactivePublisher delegate;
+    private final RabbitMQTelemetry telemetry;
+
+    TracingReactivePublisher(ReactivePublisher delegate, RabbitMQTelemetry telemetry) {
+        this.delegate = delegate;
+        this.telemetry = telemetry;
+    }
+
+    @Override
+    public Publisher<Void> publishAndConfirm(RabbitPublishState publishState) {
+        return telemetry.tracePublish(publishState, delegate::publishAndConfirm);
+    }
+
+    @Override
+    public Publisher<Void> publish(RabbitPublishState publishState) {
+        return telemetry.tracePublish(publishState, delegate::publish);
+    }
+
+    @Override
+    public Publisher<RabbitConsumerState> publishAndReply(RabbitPublishState publishState) {
+        return telemetry.tracePublishAndReply(publishState, delegate::publishAndReply);
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/package-info.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/package-info.java
@@ -16,7 +16,7 @@
 /**
  * Contains configuration that provides integration with RabbitMQ OpenTelemetry.
  *
- * @since 5.1.0
+ * @since 8.0.0
  */
 @Configuration
 @Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)

--- a/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/package-info.java
+++ b/tracing-opentelemetry-rabbitmq/src/main/java/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains configuration that provides integration with RabbitMQ OpenTelemetry.
+ *
+ * @since 5.1.0
+ */
+@Configuration
+@Requires(property = RabbitMQTelemetryConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+@Requires(classes = ReactivePublisher.class)
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.rabbitmq.reactive.ReactivePublisher;

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSpec.groovy
@@ -19,21 +19,25 @@ class RabbitMQHeadersSpec extends Specification {
     }
 
     void "getter reads carrier keys and string values"() {
+        given:
+        def getter = new RabbitMQHeadersGetter()
+
         expect:
-        RabbitMQHeadersGetter.INSTANCE.keys([traceparent: "abc", retry: 3]).toSet() == ["traceparent", "retry"].toSet()
-        RabbitMQHeadersGetter.INSTANCE.get([retry: 3], "retry") == "3"
-        RabbitMQHeadersGetter.INSTANCE.get([retry: null], "retry") == null
-        RabbitMQHeadersGetter.INSTANCE.get(null, "traceparent") == null
-        !RabbitMQHeadersGetter.INSTANCE.keys(null).iterator().hasNext()
+        getter.keys([traceparent: "abc", retry: 3]).toSet() == ["traceparent", "retry"].toSet()
+        getter.get([retry: 3], "retry") == "3"
+        getter.get([retry: null], "retry") == null
+        getter.get(null, "traceparent") == null
+        !getter.keys(null).iterator().hasNext()
     }
 
     void "setter writes only when carrier is available"() {
         given:
         def headers = [:]
+        def setter = new RabbitMQHeadersSetter()
 
         when:
-        RabbitMQHeadersSetter.INSTANCE.set(headers, "traceparent", "abc")
-        RabbitMQHeadersSetter.INSTANCE.set(null, "ignored", "value")
+        setter.set(headers, "traceparent", "abc")
+        setter.set(null, "ignored", "value")
 
         then:
         headers == [traceparent: "abc"]

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSpec.groovy
@@ -1,6 +1,9 @@
 package io.micronaut.tracing.opentelemetry.instrument.rabbitmq
 
+import com.rabbitmq.client.LongString
 import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
 
 class RabbitMQHeadersSpec extends Specification {
 
@@ -24,10 +27,39 @@ class RabbitMQHeadersSpec extends Specification {
 
         expect:
         getter.keys([traceparent: "abc", retry: 3]).toSet() == ["traceparent", "retry"].toSet()
-        getter.get([retry: 3], "retry") == "3"
+        getter.get([retry: 3], "retry") == null
         getter.get([retry: null], "retry") == null
         getter.get(null, "traceparent") == null
         !getter.keys(null).iterator().hasNext()
+    }
+
+    void "getter decodes AMQP long string and byte headers as UTF-8"() {
+        given:
+        def getter = new RabbitMQHeadersGetter()
+        def longString = Stub(LongString) {
+            length() >> 55
+            getBytes() >> "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".getBytes(StandardCharsets.UTF_8)
+        }
+
+        expect:
+        getter.get([traceparent: longString], "traceparent") == "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        getter.get([traceparent: "abc".getBytes(StandardCharsets.UTF_8)], "traceparent") == "abc"
+    }
+
+    void "getter ignores oversized propagation header values"() {
+        given:
+        def getter = new RabbitMQHeadersGetter()
+        def longString = Mock(LongString)
+
+        when:
+        def decoded = getter.get([traceparent: longString], "traceparent")
+
+        then:
+        1 * longString.length() >> RabbitMQHeadersGetter.MAX_PROPAGATION_HEADER_VALUE_BYTES + 1
+        0 * longString.getBytes()
+        decoded == null
+        getter.get([traceparent: new byte[RabbitMQHeadersGetter.MAX_PROPAGATION_HEADER_VALUE_BYTES + 1]], "traceparent") == null
+        getter.get([traceparent: "a" * (RabbitMQHeadersGetter.MAX_PROPAGATION_HEADER_VALUE_BYTES + 1)], "traceparent") == null
     }
 
     void "setter writes only when carrier is available"() {

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQHeadersSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq
+
+import spock.lang.Specification
+
+class RabbitMQHeadersSpec extends Specification {
+
+    void "configuration defaults wrapper instrumentation on"() {
+        given:
+        def configuration = new RabbitMQTelemetryConfiguration()
+
+        expect:
+        configuration.wrapper
+
+        when:
+        configuration.wrapper = false
+
+        then:
+        !configuration.wrapper
+    }
+
+    void "getter reads carrier keys and string values"() {
+        expect:
+        RabbitMQHeadersGetter.INSTANCE.keys([traceparent: "abc", retry: 3]).toSet() == ["traceparent", "retry"].toSet()
+        RabbitMQHeadersGetter.INSTANCE.get([retry: 3], "retry") == "3"
+        RabbitMQHeadersGetter.INSTANCE.get([retry: null], "retry") == null
+        RabbitMQHeadersGetter.INSTANCE.get(null, "traceparent") == null
+        !RabbitMQHeadersGetter.INSTANCE.keys(null).iterator().hasNext()
+    }
+
+    void "setter writes only when carrier is available"() {
+        given:
+        def headers = [:]
+
+        when:
+        RabbitMQHeadersSetter.INSTANCE.set(headers, "traceparent", "abc")
+        RabbitMQHeadersSetter.INSTANCE.set(null, "ignored", "value")
+
+        then:
+        headers == [traceparent: "abc"]
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryIntegrationSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryIntegrationSpec.groovy
@@ -1,0 +1,66 @@
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Property
+import io.micronaut.rabbitmq.annotation.Binding
+import io.micronaut.rabbitmq.annotation.Queue
+import io.micronaut.rabbitmq.annotation.RabbitClient
+import io.micronaut.rabbitmq.annotation.RabbitListener
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import io.micronaut.tracing.util.RabbitMQ
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import jakarta.inject.Inject
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+@MicronautTest
+@Property(name = "spec.name", value = "RabbitMQTelemetryIntegrationSpec")
+class RabbitMQTelemetryIntegrationSpec extends Specification implements TestPropertyProvider {
+
+    @Inject ProductClient productClient
+    @Inject ProductListener productListener
+    @Inject InMemorySpanExporter exporter
+
+    @Override
+    Map<String, String> getProperties() {
+        return RabbitMQ.getProperties() + [
+                'otel.register.global': 'false',
+                'micronaut.application.name': 'rabbitmq-test'
+        ]
+    }
+
+    void "rabbitmq publish and consume creates spans"() {
+        given:
+        def conditions = new PollingConditions(timeout: 30)
+
+        when:
+        productClient.send("quickstart".bytes)
+
+        then:
+        conditions.eventually {
+            productListener.messages == ["quickstart"]
+            exporter.finishedSpanItems.count { it.kind == SpanKind.PRODUCER } == 1
+            exporter.finishedSpanItems.count { it.kind == SpanKind.CONSUMER } == 1
+        }
+    }
+
+    @Requires(property = "spec.name", value = "RabbitMQTelemetryIntegrationSpec")
+    @RabbitClient
+    static interface ProductClient {
+        @Binding("product")
+        void send(byte[] data)
+    }
+
+    @Requires(property = "spec.name", value = "RabbitMQTelemetryIntegrationSpec")
+    @RabbitListener
+    static class ProductListener {
+        final List<String> messages = Collections.synchronizedList(new ArrayList<>())
+
+        @Queue("product")
+        void receive(byte[] data) {
+            messages.add(new String(data))
+        }
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryIntegrationSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryIntegrationSpec.groovy
@@ -15,6 +15,8 @@ import jakarta.inject.Inject
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.nio.charset.StandardCharsets
+
 @MicronautTest
 @Property(name = "spec.name", value = "RabbitMQTelemetryIntegrationSpec")
 class RabbitMQTelemetryIntegrationSpec extends Specification implements TestPropertyProvider {
@@ -60,7 +62,7 @@ class RabbitMQTelemetryIntegrationSpec extends Specification implements TestProp
 
         @Queue("product")
         void receive(byte[] data) {
-            messages.add(new String(data))
+            messages.add(new String(data, StandardCharsets.UTF_8))
         }
     }
 }

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryIntegrationSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/RabbitMQTelemetryIntegrationSpec.groovy
@@ -1,5 +1,9 @@
 package io.micronaut.tracing.opentelemetry.instrument.rabbitmq
 
+import com.rabbitmq.client.AMQP
+import com.rabbitmq.client.ConnectionFactory
+import com.rabbitmq.client.LongString
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Property
 import io.micronaut.rabbitmq.annotation.Binding
@@ -27,7 +31,9 @@ class RabbitMQTelemetryIntegrationSpec extends Specification implements TestProp
 
     @Override
     Map<String, String> getProperties() {
-        return RabbitMQ.getProperties() + [
+        def properties = RabbitMQ.getProperties()
+        declareQueue(properties, "product")
+        return properties + [
                 'otel.register.global': 'false',
                 'micronaut.application.name': 'rabbitmq-test'
         ]
@@ -36,16 +42,101 @@ class RabbitMQTelemetryIntegrationSpec extends Specification implements TestProp
     void "rabbitmq publish and consume creates spans"() {
         given:
         def conditions = new PollingConditions(timeout: 30)
+        String message = "quickstart-${UUID.randomUUID()}"
+        exporter.reset()
+        productListener.messages.clear()
 
         when:
-        productClient.send("quickstart".bytes)
+        productClient.send(message.getBytes(StandardCharsets.UTF_8))
 
         then:
         conditions.eventually {
-            productListener.messages == ["quickstart"]
-            exporter.finishedSpanItems.count { it.kind == SpanKind.PRODUCER } == 1
-            exporter.finishedSpanItems.count { it.kind == SpanKind.CONSUMER } == 1
+            def spans = exporter.finishedSpanItems.toList()
+            def producer = spans.find { it.kind == SpanKind.PRODUCER }
+            def consumer = spans.find { it.kind == SpanKind.CONSUMER }
+            assert productListener.messages.contains(message)
+            assert spans.count { it.kind == SpanKind.PRODUCER } == 1
+            assert spans.count { it.kind == SpanKind.CONSUMER } == 1
+            assert producer != null
+            assert consumer != null
+            assert consumer.spanContext.traceId == producer.spanContext.traceId
+            assert consumer.parentSpanContext.spanId == producer.spanContext.spanId
+            assert consumer.parentSpanContext.remote
+            assert producer.attributes.get(RabbitMQTelemetry.MESSAGING_SYSTEM) == "rabbitmq"
+            assert producer.attributes.get(RabbitMQTelemetry.MESSAGING_OPERATION) == "publish"
+            assert producer.attributes.get(RabbitMQTelemetry.MESSAGING_OPERATION_NAME) == "publish"
+            assert producer.attributes.get(RabbitMQTelemetry.MESSAGING_OPERATION_TYPE) == "send"
+            assert producer.attributes.get(RabbitMQTelemetry.DESTINATION) == "product"
+            assert consumer.attributes.get(RabbitMQTelemetry.MESSAGING_SYSTEM) == "rabbitmq"
+            assert consumer.attributes.get(RabbitMQTelemetry.MESSAGING_OPERATION) == "process"
+            assert consumer.attributes.get(RabbitMQTelemetry.MESSAGING_OPERATION_NAME) == "process"
+            assert consumer.attributes.get(RabbitMQTelemetry.MESSAGING_OPERATION_TYPE) == "process"
+            assert consumer.attributes.get(RabbitMQTelemetry.ROUTING_KEY) == "product"
+            assert consumer.attributes.get(RabbitMQTelemetry.DELIVERY_TAG) > 0
         }
+    }
+
+    void "broker round trip exposes string headers as decodable AMQP values"() {
+        given:
+        def conditions = new PollingConditions(timeout: 10)
+        def queue = "trace-headers-${UUID.randomUUID()}"
+        def traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        def factory = connectionFactory()
+        def connection = factory.newConnection()
+        def channel = connection.createChannel()
+        Map<String, Object> deliveredHeaders = null
+
+        when:
+        channel.queueDeclare(queue, false, true, true, null)
+        channel.basicPublish("", queue, new AMQP.BasicProperties.Builder().headers([traceparent: traceparent]).build(), "body".getBytes(StandardCharsets.UTF_8))
+
+        then:
+        conditions.eventually {
+            def response = channel.basicGet(queue, true)
+            assert response != null
+            deliveredHeaders = response.props.headers
+            assert deliveredHeaders.traceparent instanceof LongString || deliveredHeaders.traceparent instanceof String
+            assert new RabbitMQHeadersGetter().get(deliveredHeaders, "traceparent") == traceparent
+        }
+
+        cleanup:
+        channel?.queueDelete(queue)
+        channel?.close()
+        connection?.close()
+    }
+
+    void "enabled false removes RabbitMQ telemetry beans"() {
+        when:
+        def context = ApplicationContext.run([
+                'otel.instrumentation.rabbitmq.enabled': 'false',
+                'otel.register.global': 'false'
+        ])
+
+        then:
+        !context.containsBean(RabbitMQTelemetryConfiguration)
+        !context.containsBean(RabbitMQTelemetry)
+        !context.containsBean(RabbitMQReactivePublisherTracingInstrumentation)
+        !context.containsBean(RabbitMQChannelPoolTracingInstrumentation)
+
+        cleanup:
+        context.close()
+    }
+
+    void "wrapper false keeps telemetry bean without wrapper instrumentation"() {
+        when:
+        def context = ApplicationContext.run([
+                'otel.instrumentation.rabbitmq.wrapper': 'false',
+                'otel.register.global': 'false'
+        ])
+
+        then:
+        context.containsBean(RabbitMQTelemetryConfiguration)
+        context.containsBean(RabbitMQTelemetry)
+        !context.containsBean(RabbitMQReactivePublisherTracingInstrumentation)
+        !context.containsBean(RabbitMQChannelPoolTracingInstrumentation)
+
+        cleanup:
+        context.close()
     }
 
     @Requires(property = "spec.name", value = "RabbitMQTelemetryIntegrationSpec")
@@ -63,6 +154,27 @@ class RabbitMQTelemetryIntegrationSpec extends Specification implements TestProp
         @Queue("product")
         void receive(byte[] data) {
             messages.add(new String(data, StandardCharsets.UTF_8))
+        }
+    }
+
+    private static ConnectionFactory connectionFactory() {
+        connectionFactory(RabbitMQ.getProperties())
+    }
+
+    private static ConnectionFactory connectionFactory(Map<String, String> properties) {
+        def factory = new ConnectionFactory()
+        factory.setUri(properties["rabbitmq.uri"])
+        factory
+    }
+
+    private static void declareQueue(Map<String, String> properties, String queue) {
+        def connection = connectionFactory(properties).newConnection()
+        def channel = connection.createChannel()
+        try {
+            channel.queueDeclare(queue, false, false, false, null)
+        } finally {
+            channel.close()
+            connection.close()
         }
     }
 }

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq
+
+import com.rabbitmq.client.AMQP
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Consumer
+import com.rabbitmq.client.Envelope
+import io.micronaut.rabbitmq.connect.ChannelPool
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import spock.lang.Specification
+
+class TracingChannelPoolSpec extends Specification {
+
+    void "channel wrapper traces consumer deliveries"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
+                .build()
+        def telemetry = new RabbitMQTelemetry(openTelemetry)
+        def delegateChannel = Mock(Channel)
+        def delegatePool = Stub(ChannelPool) {
+            getName() >> "default"
+            getChannel() >> delegateChannel
+            isTopologyRecoveryEnabled() >> true
+        }
+        def pool = new TracingChannelPool(delegatePool, telemetry)
+        def consumer = Mock(Consumer)
+
+        when:
+        def channel = pool.getChannel()
+        channel.basicConsume("orders", true, consumer)
+
+        then:
+        1 * delegateChannel.basicConsume("orders", true, _ as Consumer) >> { String queue, boolean autoAck, Consumer wrapped ->
+            wrapped.handleDelivery("consumer", new Envelope(1L, false, "orders-exchange", "orders"), new AMQP.BasicProperties.Builder().headers([traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"]).build(), "body".bytes)
+            "consumer"
+        }
+        1 * consumer.handleDelivery("consumer", _ as Envelope, _ as AMQP.BasicProperties, "body".bytes)
+        exporter.finishedSpanItems.size() == 1
+        exporter.finishedSpanItems[0].kind.name() == "CONSUMER"
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
@@ -4,10 +4,11 @@ import com.rabbitmq.client.AMQP
 import com.rabbitmq.client.Channel
 import com.rabbitmq.client.Consumer
 import com.rabbitmq.client.Envelope
+import io.micronaut.context.event.BeanCreatedEvent
 import io.micronaut.rabbitmq.connect.ChannelPool
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -19,12 +20,7 @@ class TracingChannelPoolSpec extends Specification {
     void "channel wrapper traces consumer deliveries"() {
         given:
         def exporter = InMemorySpanExporter.create()
-        OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-                .setTracerProvider(SdkTracerProvider.builder()
-                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
-                        .build())
-                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
-                .build()
+        OpenTelemetry openTelemetry = openTelemetry(exporter)
         def telemetry = new RabbitMQTelemetry(openTelemetry)
         def delegateChannel = Mock(Channel)
         def delegatePool = Stub(ChannelPool) {
@@ -47,5 +43,91 @@ class TracingChannelPoolSpec extends Specification {
         1 * consumer.handleDelivery("consumer", _ as Envelope, _ as AMQP.BasicProperties, "body".bytes)
         exporter.finishedSpanItems.size() == 1
         exporter.finishedSpanItems[0].kind.name() == "CONSUMER"
+    }
+
+    void "channel pool delegates metadata and unwraps returned channels"() {
+        given:
+        def telemetry = new RabbitMQTelemetry(openTelemetry(InMemorySpanExporter.create()))
+        def delegateChannel = Mock(Channel)
+        def delegatePool = Mock(ChannelPool)
+        def pool = new TracingChannelPool(delegatePool, telemetry)
+
+        when:
+        def name = pool.name
+        def topologyRecovery = pool.topologyRecoveryEnabled
+        def channel = pool.getChannelWithRecoveringDelay(3)
+        pool.returnChannel(channel)
+
+        then:
+        name == "default"
+        topologyRecovery
+        channel instanceof RabbitMQTelemetry.TracingChannel
+        1 * delegatePool.getName() >> "default"
+        1 * delegatePool.isTopologyRecoveryEnabled() >> true
+        1 * delegatePool.getChannelWithRecoveringDelay(3) >> delegateChannel
+        1 * delegatePool.returnChannel(delegateChannel)
+    }
+
+    void "channel pool instrumentation preserves existing tracing wrapper"() {
+        given:
+        def telemetry = new RabbitMQTelemetry(openTelemetry(InMemorySpanExporter.create()))
+        def delegatePool = Stub(ChannelPool)
+        def pool = new TracingChannelPool(delegatePool, telemetry)
+        def instrumentation = new RabbitMQChannelPoolTracingInstrumentation(telemetry)
+        def event = Stub(BeanCreatedEvent) {
+            getBean() >> pool
+        }
+
+        expect:
+        instrumentation.onCreated(event).is(pool)
+    }
+
+    void "consumer wrapper delegates lifecycle callbacks"() {
+        given:
+        def telemetry = new RabbitMQTelemetry(openTelemetry(InMemorySpanExporter.create()))
+        def delegate = Mock(Consumer)
+        def consumer = new TracingConsumer(delegate, telemetry)
+
+        when:
+        consumer.handleConsumeOk("tag")
+        consumer.handleCancelOk("tag")
+        consumer.handleCancel("tag")
+        consumer.handleShutdownSignal("tag", null)
+        consumer.handleRecoverOk("tag")
+
+        then:
+        1 * delegate.handleConsumeOk("tag")
+        1 * delegate.handleCancelOk("tag")
+        1 * delegate.handleCancel("tag")
+        1 * delegate.handleShutdownSignal("tag", null)
+        1 * delegate.handleRecoverOk("tag")
+    }
+
+    void "delivery failures record span error"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        def telemetry = new RabbitMQTelemetry(openTelemetry(exporter))
+        def delegate = Mock(Consumer)
+        def consumer = new TracingConsumer(delegate, telemetry)
+        def failure = new IOException("boom")
+
+        when:
+        consumer.handleDelivery("consumer", null, null, "body".bytes)
+
+        then:
+        1 * delegate.handleDelivery("consumer", null, null, "body".bytes) >> { throw failure }
+        def e = thrown(IOException)
+        e.is(failure)
+        exporter.finishedSpanItems.size() == 1
+        exporter.finishedSpanItems[0].status.statusCode.name() == "ERROR"
+    }
+
+    private static OpenTelemetry openTelemetry(InMemorySpanExporter exporter) {
+        OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
+                .build()
     }
 }

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
@@ -134,6 +134,7 @@ class TracingChannelPoolSpec extends Specification {
         e.is(failure)
         exporter.finishedSpanItems.size() == 1
         exporter.finishedSpanItems[0].status.statusCode.name() == "ERROR"
+        exporter.finishedSpanItems[0].attributes.get(RabbitMQTelemetry.ERROR_TYPE) == IOException.name
     }
 
     private static OpenTelemetry openTelemetry(InMemorySpanExporter exporter) {

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingChannelPoolSpec.groovy
@@ -68,6 +68,20 @@ class TracingChannelPoolSpec extends Specification {
         1 * delegatePool.returnChannel(delegateChannel)
     }
 
+    void "channel wrapping is idempotent"() {
+        given:
+        def telemetry = new RabbitMQTelemetry(openTelemetry(InMemorySpanExporter.create()))
+        def delegateChannel = Mock(Channel)
+
+        when:
+        def wrapped = telemetry.wrap(delegateChannel)
+        def wrappedAgain = telemetry.wrap(wrapped)
+
+        then:
+        wrappedAgain.is(wrapped)
+        telemetry.unwrap(wrappedAgain).is(delegateChannel)
+    }
+
     void "channel pool instrumentation preserves existing tracing wrapper"() {
         given:
         def telemetry = new RabbitMQTelemetry(openTelemetry(InMemorySpanExporter.create()))

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
@@ -7,12 +7,17 @@ import io.micronaut.rabbitmq.reactive.ReactivePublisher
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import reactor.core.publisher.Mono
 import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
 
 class TracingReactivePublisherSpec extends Specification {
 
@@ -36,6 +41,34 @@ class TracingReactivePublisherSpec extends Specification {
         exporter.finishedSpanItems.size() == 1
         exporter.finishedSpanItems[0].kind.name() == "PRODUCER"
         exporter.finishedSpanItems[0].attributes.asMap().values().contains("rabbitmq")
+    }
+
+    void "publish does not start a span before subscription"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        def spanProcessor = new CountingSpanProcessor()
+        def telemetry = new RabbitMQTelemetry(openTelemetry(exporter, spanProcessor))
+        def delegate = Mock(ReactivePublisher)
+        def publisher = new TracingReactivePublisher(delegate, telemetry)
+        def publishState = new RabbitPublishState("orders", "created", false, new AMQP.BasicProperties(), "hello".bytes)
+
+        when:
+        def result = publisher.publish(publishState)
+
+        then:
+        0 * delegate._
+        spanProcessor.started.get() == 0
+        spanProcessor.ended.get() == 0
+        exporter.finishedSpanItems.empty
+
+        when:
+        Mono.from(result).block()
+
+        then:
+        1 * delegate.publish(_) >> Mono.empty()
+        spanProcessor.started.get() == 1
+        spanProcessor.ended.get() == 1
+        exporter.finishedSpanItems.size() == 1
     }
 
     void "publish and confirm emits a producer span"() {
@@ -130,11 +163,41 @@ class TracingReactivePublisherSpec extends Specification {
     }
 
     private static OpenTelemetry openTelemetry(InMemorySpanExporter exporter) {
+        openTelemetry(exporter, [] as SpanProcessor[])
+    }
+
+    private static OpenTelemetry openTelemetry(InMemorySpanExporter exporter, SpanProcessor... spanProcessors) {
+        def tracerProviderBuilder = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        spanProcessors.each { tracerProviderBuilder.addSpanProcessor(it) }
         OpenTelemetrySdk.builder()
-                .setTracerProvider(SdkTracerProvider.builder()
-                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
-                        .build())
-                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
-                .build()
+            .setTracerProvider(tracerProviderBuilder.build())
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
+            .build()
+    }
+
+    private static final class CountingSpanProcessor implements SpanProcessor {
+        final AtomicInteger started = new AtomicInteger()
+        final AtomicInteger ended = new AtomicInteger()
+
+        @Override
+        void onStart(io.opentelemetry.context.Context parentContext, ReadWriteSpan span) {
+            started.incrementAndGet()
+        }
+
+        @Override
+        boolean isStartRequired() {
+            true
+        }
+
+        @Override
+        void onEnd(ReadableSpan span) {
+            ended.incrementAndGet()
+        }
+
+        @Override
+        boolean isEndRequired() {
+            true
+        }
     }
 }

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.tracing.opentelemetry.instrument.rabbitmq
+
+import com.rabbitmq.client.AMQP
+import io.micronaut.rabbitmq.reactive.RabbitPublishState
+import io.micronaut.rabbitmq.reactive.ReactivePublisher
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+class TracingReactivePublisherSpec extends Specification {
+
+    void "publish injects trace headers and emits a producer span"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
+                .build()
+        def telemetry = new RabbitMQTelemetry(openTelemetry)
+        def delegate = Mock(ReactivePublisher)
+        def publisher = new TracingReactivePublisher(delegate, telemetry)
+        def publishState = new RabbitPublishState("orders", "created", false, new AMQP.BasicProperties(), "hello".bytes)
+
+        when:
+        Mono.from(publisher.publish(publishState)).block()
+
+        then:
+        1 * delegate.publish(_) >> { RabbitPublishState state ->
+            assert state.properties.headers.traceparent
+            Mono.empty()
+        }
+        exporter.finishedSpanItems.size() == 1
+        exporter.finishedSpanItems[0].kind.name() == "PRODUCER"
+        exporter.finishedSpanItems[0].attributes.asMap().values().contains("rabbitmq")
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
@@ -1,11 +1,12 @@
 package io.micronaut.tracing.opentelemetry.instrument.rabbitmq
 
 import com.rabbitmq.client.AMQP
+import io.micronaut.context.event.BeanCreatedEvent
 import io.micronaut.rabbitmq.reactive.RabbitPublishState
 import io.micronaut.rabbitmq.reactive.ReactivePublisher
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -18,12 +19,7 @@ class TracingReactivePublisherSpec extends Specification {
     void "publish injects trace headers and emits a producer span"() {
         given:
         def exporter = InMemorySpanExporter.create()
-        OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-                .setTracerProvider(SdkTracerProvider.builder()
-                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
-                        .build())
-                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
-                .build()
+        OpenTelemetry openTelemetry = openTelemetry(exporter)
         def telemetry = new RabbitMQTelemetry(openTelemetry)
         def delegate = Mock(ReactivePublisher)
         def publisher = new TracingReactivePublisher(delegate, telemetry)
@@ -40,5 +36,105 @@ class TracingReactivePublisherSpec extends Specification {
         exporter.finishedSpanItems.size() == 1
         exporter.finishedSpanItems[0].kind.name() == "PRODUCER"
         exporter.finishedSpanItems[0].attributes.asMap().values().contains("rabbitmq")
+    }
+
+    void "publish and confirm emits a producer span"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        def telemetry = new RabbitMQTelemetry(openTelemetry(exporter))
+        def delegate = Mock(ReactivePublisher)
+        def publisher = new TracingReactivePublisher(delegate, telemetry)
+        def publishState = new RabbitPublishState("", "created", true, new AMQP.BasicProperties(), "hello".bytes)
+
+        when:
+        Mono.from(publisher.publishAndConfirm(publishState)).block()
+
+        then:
+        1 * delegate.publishAndConfirm(_) >> Mono.empty()
+        exporter.finishedSpanItems.size() == 1
+        exporter.finishedSpanItems[0].attributes.asMap().values().contains("created")
+    }
+
+    void "publish and reply returns consumer state and emits a producer span"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        def telemetry = new RabbitMQTelemetry(openTelemetry(exporter))
+        def delegate = Mock(ReactivePublisher)
+        def publisher = new TracingReactivePublisher(delegate, telemetry)
+        def publishState = new RabbitPublishState("orders", "created", false, new AMQP.BasicProperties.Builder().headers([existing: "value"]).build(), "hello".bytes)
+        def replyState = Mock(io.micronaut.rabbitmq.bind.RabbitConsumerState)
+
+        when:
+        def result = Mono.from(publisher.publishAndReply(publishState)).block()
+
+        then:
+        result.is(replyState)
+        1 * delegate.publishAndReply(_) >> { RabbitPublishState state ->
+            assert state.properties.headers.existing == "value"
+            assert state.properties.headers.traceparent
+            Mono.just(replyState)
+        }
+        exporter.finishedSpanItems.size() == 1
+    }
+
+    void "synchronous publish failure records span error"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        def telemetry = new RabbitMQTelemetry(openTelemetry(exporter))
+        def delegate = Mock(ReactivePublisher)
+        def publisher = new TracingReactivePublisher(delegate, telemetry)
+        def publishState = new RabbitPublishState("orders", "created", false, new AMQP.BasicProperties(), "hello".bytes)
+        def failure = new IllegalStateException("boom")
+
+        when:
+        Mono.from(publisher.publish(publishState)).block()
+
+        then:
+        1 * delegate.publish(_) >> { throw failure }
+        def e = thrown(IllegalStateException)
+        e.is(failure)
+        exporter.finishedSpanItems.size() == 1
+        exporter.finishedSpanItems[0].status.statusCode.name() == "ERROR"
+    }
+
+    void "asynchronous publish failure records span error"() {
+        given:
+        def exporter = InMemorySpanExporter.create()
+        def telemetry = new RabbitMQTelemetry(openTelemetry(exporter))
+        def delegate = Mock(ReactivePublisher)
+        def publisher = new TracingReactivePublisher(delegate, telemetry)
+        def publishState = new RabbitPublishState("orders", "created", false, new AMQP.BasicProperties(), "hello".bytes)
+
+        when:
+        Mono.from(publisher.publish(publishState)).block()
+
+        then:
+        1 * delegate.publish(_) >> Mono.error(new IllegalArgumentException("boom"))
+        thrown(IllegalArgumentException)
+        exporter.finishedSpanItems.size() == 1
+        exporter.finishedSpanItems[0].status.statusCode.name() == "ERROR"
+    }
+
+    void "reactive publisher instrumentation preserves existing tracing wrapper"() {
+        given:
+        def telemetry = new RabbitMQTelemetry(openTelemetry(InMemorySpanExporter.create()))
+        def delegate = Mock(ReactivePublisher)
+        def publisher = new TracingReactivePublisher(delegate, telemetry)
+        def instrumentation = new RabbitMQReactivePublisherTracingInstrumentation(telemetry)
+        def event = Stub(BeanCreatedEvent) {
+            getBean() >> publisher
+        }
+
+        expect:
+        instrumentation.onCreated(event).is(publisher)
+    }
+
+    private static OpenTelemetry openTelemetry(InMemorySpanExporter exporter) {
+        OpenTelemetrySdk.builder()
+                .setTracerProvider(SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build())
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.instance))
+                .build()
     }
 }

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/rabbitmq/TracingReactivePublisherSpec.groovy
@@ -128,6 +128,7 @@ class TracingReactivePublisherSpec extends Specification {
         e.is(failure)
         exporter.finishedSpanItems.size() == 1
         exporter.finishedSpanItems[0].status.statusCode.name() == "ERROR"
+        exporter.finishedSpanItems[0].attributes.get(RabbitMQTelemetry.ERROR_TYPE) == IllegalStateException.name
     }
 
     void "asynchronous publish failure records span error"() {
@@ -146,6 +147,7 @@ class TracingReactivePublisherSpec extends Specification {
         thrown(IllegalArgumentException)
         exporter.finishedSpanItems.size() == 1
         exporter.finishedSpanItems[0].status.statusCode.name() == "ERROR"
+        exporter.finishedSpanItems[0].attributes.get(RabbitMQTelemetry.ERROR_TYPE) == IllegalArgumentException.name
     }
 
     void "reactive publisher instrumentation preserves existing tracing wrapper"() {

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/util/RabbitMQ.java
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/util/RabbitMQ.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.util;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.util.Map;
+
+public final class RabbitMQ {
+    private static GenericContainer<?> container;
+
+    private RabbitMQ() {
+    }
+
+    public static Map<String, String> getProperties() {
+        if (container == null) {
+            container = new GenericContainer<>("rabbitmq:3.13")
+                .withExposedPorts(5672)
+                .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Server startup complete.*"));
+            container.start();
+        }
+        return Map.of(
+            "rabbitmq.uri", "amqp://guest:guest@%s:%d".formatted(container.getHost(), container.getMappedPort(5672)),
+            "rabbitmq.username", "guest",
+            "rabbitmq.password", "guest"
+        );
+    }
+}

--- a/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry-rabbitmq/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.util;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.tracing.opentelemetry.DefaultOpenTelemetryFactory;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import jakarta.inject.Singleton;
+
+/**
+ * Registers an OpenTelemetry bean for test.
+ */
+@Factory
+@Replaces(factory = DefaultOpenTelemetryFactory.class)
+public class TestDefaultOpenTelemetryFactory {
+
+    @Singleton
+    @Primary
+    OpenTelemetry defaultOpenTelemetry(InMemorySpanExporter inMemorySpanExporter) {
+        return OpenTelemetrySdk.builder()
+            .setTracerProvider(SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(inMemorySpanExporter))
+                .build()
+            )
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+            .build();
+    }
+
+    @Singleton
+    InMemorySpanExporter inMemorySpanExporter() {
+        return InMemorySpanExporter.create();
+    }
+}


### PR DESCRIPTION
## Summary
- add a `micronaut-tracing-opentelemetry-rabbitmq` module that instruments RabbitMQ publishers, channel pools, and consumers with OpenTelemetry spans and propagated headers
- register the new module in the build and document how to enable or disable the instrumentation
- cover the new RabbitMQ telemetry behavior with publisher, channel pool, and integration tests
- address review feedback by preserving existing tracing channel wrappers, removing unused Testcontainers catalog aliases, using explicit UTF-8 decoding, and avoiding singleton header helper instances

## Verification
- `./gradlew :micronaut-tracing-opentelemetry-rabbitmq:test --tests '*RabbitMQHeadersSpec' --tests '*TracingChannelPoolSpec' --tests '*TracingReactivePublisherSpec' -q`
- `./gradlew :micronaut-tracing-opentelemetry-rabbitmq:test -q`
- `./gradlew :micronaut-tracing-opentelemetry-rabbitmq:check -q -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew :micronaut-tracing-opentelemetry-rabbitmq:spotlessCheck -q`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/739
