### PR TITLE
Support OpenTelemetry resource attributes

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.tracing-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.tracing-module.gradle
@@ -9,6 +9,8 @@ ossIndexAudit {
     ]
 }
 dependencies {
+    api platform(libs.boms.netty)
+
     annotationProcessor mn.micronaut.inject.java
     annotationProcessor libs.micronaut.docs.asciidoc.config.props
 

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.tracing-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.tracing-module.gradle
@@ -9,8 +9,6 @@ ossIndexAudit {
     ]
 }
 dependencies {
-    api platform(libs.boms.netty)
-
     annotationProcessor mn.micronaut.inject.java
     annotationProcessor libs.micronaut.docs.asciidoc.config.props
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ managed-jaeger = '1.8.1'
 managed-opentracing = '0.33.0'
 managed-opentracing-grpc = '0.2.3'
 managed-brave-opentracing = '1.0.1'
-
 javax-annotation = '1.3.2'
 grpc = '1.80.0'
 protobuf = '3.25.8'
@@ -112,7 +111,6 @@ boms-opentelemetry-instrumentation = { module = 'io.opentelemetry.instrumentatio
 boms-opentelemetry-instrumentation-alpha = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha', version.ref = 'managed-opentelemetry-instrumentation-alpha' }
 boms-brave = { module = 'io.zipkin.brave:brave-bom', version.ref = 'managed-brave-instrumentation' }
 boms-zipkin-reporter = { module = 'io.zipkin.reporter2:zipkin-reporter-bom', version.ref = 'managed-zipkin-reporter' }
-
 #plugins
 micronaut-gradle-plugin = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref="micronaut-gradle-plugin" }
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ managed-jaeger = '1.8.1'
 managed-opentracing = '0.33.0'
 managed-opentracing-grpc = '0.2.3'
 managed-brave-opentracing = '1.0.1'
+managed-netty = '4.2.12.Final'
 
 javax-annotation = '1.3.2'
 grpc = '1.80.0'
@@ -112,6 +113,7 @@ boms-opentelemetry-instrumentation = { module = 'io.opentelemetry.instrumentatio
 boms-opentelemetry-instrumentation-alpha = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha', version.ref = 'managed-opentelemetry-instrumentation-alpha' }
 boms-brave = { module = 'io.zipkin.brave:brave-bom', version.ref = 'managed-brave-instrumentation' }
 boms-zipkin-reporter = { module = 'io.zipkin.reporter2:zipkin-reporter-bom', version.ref = 'managed-zipkin-reporter' }
+boms-netty = { module = 'io.netty:netty-bom', version.ref = 'managed-netty' }
 
 #plugins
 micronaut-gradle-plugin = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref="micronaut-gradle-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ managed-jaeger = '1.8.1'
 managed-opentracing = '0.33.0'
 managed-opentracing-grpc = '0.2.3'
 managed-brave-opentracing = '1.0.1'
-managed-netty = '4.2.12.Final'
 
 javax-annotation = '1.3.2'
 grpc = '1.80.0'
@@ -113,7 +112,6 @@ boms-opentelemetry-instrumentation = { module = 'io.opentelemetry.instrumentatio
 boms-opentelemetry-instrumentation-alpha = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha', version.ref = 'managed-opentelemetry-instrumentation-alpha' }
 boms-brave = { module = 'io.zipkin.brave:brave-bom', version.ref = 'managed-brave-instrumentation' }
 boms-zipkin-reporter = { module = 'io.zipkin.reporter2:zipkin-reporter-bom', version.ref = 'managed-zipkin-reporter' }
-boms-netty = { module = 'io.netty:netty-bom', version.ref = 'managed-netty' }
 
 #plugins
 micronaut-gradle-plugin = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref="micronaut-gradle-plugin" }

--- a/src/main/docs/guide/opentelemetry.adoc
+++ b/src/main/docs/guide/opentelemetry.adoc
@@ -9,6 +9,8 @@ OpenTelemetry libraries must be resolved using the same BOM or platform dependen
 If an application overrides the Micronaut Tracing version supplied by the Micronaut Platform BOM, also import the matching `io.micronaut.tracing:micronaut-tracing-bom` version.
 This keeps OpenTelemetry instrumentation, semantic conventions, SDK, and exporter dependencies aligned.
 
+Standard OpenTelemetry resource configuration is also supported. For example, you can set `otel.resource.attributes=deployment.environment=prod,service.namespace=payments` or use the equivalent `OTEL_RESOURCE_ATTRIBUTES` environment variable.
+
 == OpenTelemetry annotations
 
 The pkg:tracing.opentelemetry.processing[] package contains transformers and mappers that enables usage of Open Telemetry annotations.

--- a/tracing-bom/build.gradle
+++ b/tracing-bom/build.gradle
@@ -44,6 +44,12 @@ micronautBom {
                         "io.zipkin.proto3"
                 ] as Set
         )
+        bomAuthorizedGroupIds.put(
+                "io.netty:netty-bom",
+                [
+                        "io.netty"
+                ] as Set
+        )
         dependencies.add("io.opentelemetry.semconv:opentelemetry-semconv:1.40.0")
         dependencies.add("io.opentelemetry:opentelemetry-bom:1.61.0")
         dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.61.0-alpha")
@@ -51,7 +57,6 @@ micronautBom {
         dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.27.0-alpha")
         dependencies.add("io.zipkin.brave:brave-instrumentation-benchmarks:6.1.0")
         dependencies.add("io.zipkin.reporter2:zipkin-reporter-bom:3.5.1")
-
-
+        dependencies.add("io.netty:netty-bom:4.2.12.Final")
     }
 }

--- a/tracing-bom/build.gradle
+++ b/tracing-bom/build.gradle
@@ -44,12 +44,6 @@ micronautBom {
                         "io.zipkin.proto3"
                 ] as Set
         )
-        bomAuthorizedGroupIds.put(
-                "io.netty:netty-bom",
-                [
-                        "io.netty"
-                ] as Set
-        )
         dependencies.add("io.opentelemetry.semconv:opentelemetry-semconv:1.40.0")
         dependencies.add("io.opentelemetry:opentelemetry-bom:1.61.0")
         dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.61.0-alpha")
@@ -57,6 +51,5 @@ micronautBom {
         dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.27.0-alpha")
         dependencies.add("io.zipkin.brave:brave-instrumentation-benchmarks:6.1.0")
         dependencies.add("io.zipkin.reporter2:zipkin-reporter-bom:3.5.1")
-        dependencies.add("io.netty:netty-bom:4.2.12.Final")
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -26,7 +26,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
-import io.opentelemetry.sdk.autoconfigure.ResourceConfiguration;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -34,6 +33,7 @@ import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -46,6 +46,7 @@ import java.util.Map;
 public class DefaultOpenTelemetryFactory {
 
     private static final String SERVICE_NAME_KEY = "otel.service.name";
+    private static final String RESOURCE_ATTRIBUTES_KEY = "otel.resource.attributes";
     private static final String DEFAULT_TRACES_EXPORTER = "otel.traces.exporter";
     private static final String DEFAULT_METRICS_EXPORTER = "otel.metrics.exporter";
     private static final String DEFAULT_LOGS_EXPORTER = "otel.logs.exporter";
@@ -92,7 +93,6 @@ public class DefaultOpenTelemetryFactory {
         }
 
         sdk.addResourceCustomizer((resource, config) -> {
-                resource = resource.merge(ResourceConfiguration.createEnvironmentResource(config));
                 if (resourceProvider != null) {
                     resource = resource.merge(resourceProvider.resource());
                 }
@@ -132,12 +132,21 @@ public class DefaultOpenTelemetryFactory {
     }
 
     private Map<String, String> resolveOtelProperties(Environment environment) {
-        return environment.getProperties("otel", StringConvention.RAW).entrySet().stream().collect(
+        Map<String, String> otel = environment.getProperties("otel", StringConvention.RAW).entrySet().stream().collect(
             java.util.stream.Collectors.toMap(
-                entry -> "otel." + entry.getKey(),
-                entry -> String.valueOf(entry.getValue())
+                entry -> "otel." + normalizeOtelProperty(entry.getKey()),
+                entry -> String.valueOf(entry.getValue()),
+                (existing, replacement) -> existing
             )
         );
+        environment.getProperty(RESOURCE_ATTRIBUTES_KEY, String.class).ifPresent(attributes ->
+            otel.putIfAbsent(RESOURCE_ATTRIBUTES_KEY, attributes)
+        );
+        return otel;
+    }
+
+    private String normalizeOtelProperty(String property) {
+        return property.toLowerCase(Locale.ENGLISH).replace('_', '.');
     }
 
     /**

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -16,10 +16,9 @@
 package io.micronaut.tracing.opentelemetry;
 
 import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -27,6 +26,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.autoconfigure.ResourceConfiguration;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -35,9 +35,6 @@ import jakarta.inject.Singleton;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static io.micronaut.core.convert.format.MapFormat.MapTransformation.FLAT;
 
 /**
  * Registers an OpenTelemetry bean.
@@ -59,7 +56,7 @@ public class DefaultOpenTelemetryFactory {
      * The OpenTelemetry bean with default values.
      *
      * @param applicationConfiguration the {@link ApplicationConfiguration}
-     * @param otelConfig               the configuration values for the opentelemetry autoconfigure
+     * @param environment              the environment property resolver
      * @param idGenerator              the {@link IdGenerator}
      * @param spanProcessor            the {@link SpanProcessor}
      * @param resourceProvider         Resource Provider
@@ -69,7 +66,7 @@ public class DefaultOpenTelemetryFactory {
      */
     @Singleton
     protected OpenTelemetry defaultOpenTelemetry(ApplicationConfiguration applicationConfiguration,
-                                                 @Property(name = "otel") @MapFormat(transformation = FLAT) Map<String, String> otelConfig,
+                                                 Environment environment,
                                                  @Nullable IdGenerator idGenerator,
                                                  @Nullable SpanProcessor spanProcessor,
                                                  @Nullable ResourceProvider resourceProvider,
@@ -81,12 +78,9 @@ public class DefaultOpenTelemetryFactory {
             return existingGlobalOpenTelemetry;
         }
 
-        Map<String, String> otel = otelConfig.entrySet().stream().collect(Collectors.toMap(
-            e -> "otel." + e.getKey(),
-            Map.Entry::getValue
-        ));
+        Map<String, String> otel = resolveOtelProperties(environment);
 
-        otel.putIfAbsent(SERVICE_NAME_KEY, applicationConfiguration.getName().orElse(""));
+        applicationConfiguration.getName().ifPresent(name -> otel.putIfAbsent(SERVICE_NAME_KEY, name));
         otel.putIfAbsent(DEFAULT_TRACES_EXPORTER, NONE);
         otel.putIfAbsent(DEFAULT_METRICS_EXPORTER, NONE);
         otel.putIfAbsent(DEFAULT_LOGS_EXPORTER, NONE);
@@ -97,16 +91,20 @@ public class DefaultOpenTelemetryFactory {
             sdk.setResultAsGlobal();
         }
 
-        sdk.addPropertiesSupplier(() -> otel)
+        sdk.addResourceCustomizer((resource, config) -> {
+                resource = resource.merge(ResourceConfiguration.createEnvironmentResource(config));
+                if (resourceProvider != null) {
+                    resource = resource.merge(resourceProvider.resource());
+                }
+                return resource;
+            })
+            .addPropertiesSupplier(() -> otel)
             .addTracerProviderCustomizer((tracerProviderBuilder, ignored) -> {
                     if (idGenerator != null) {
                         tracerProviderBuilder.setIdGenerator(idGenerator);
                     }
                     if (spanProcessor != null) {
                         tracerProviderBuilder.addSpanProcessor(spanProcessor);
-                    }
-                    if (resourceProvider != null) {
-                        tracerProviderBuilder.setResource(resourceProvider.resource());
                     }
                     if (sampler != null) {
                         tracerProviderBuilder.setSampler(sampler);
@@ -131,6 +129,15 @@ public class DefaultOpenTelemetryFactory {
 
         OpenTelemetry globalOpenTelemetry = GlobalOpenTelemetry.get();
         return globalOpenTelemetry.getTracerProvider() == TracerProvider.noop() ? null : globalOpenTelemetry;
+    }
+
+    private Map<String, String> resolveOtelProperties(Environment environment) {
+        return environment.getProperties("otel", StringConvention.RAW).entrySet().stream().collect(
+            java.util.stream.Collectors.toMap(
+                entry -> "otel." + entry.getKey(),
+                entry -> String.valueOf(entry.getValue())
+            )
+        );
     }
 
     /**

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/OpenTelemetryResourceAttributesSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/OpenTelemetryResourceAttributesSpec.groovy
@@ -1,0 +1,65 @@
+package io.micronaut.tracing.opentelemetry
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SpanProcessor
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class OpenTelemetryResourceAttributesSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
+            'spec.name': 'OpenTelemetryResourceAttributesSpec',
+            'otel.resource.attributes': 'deployment.environment=test,service.namespace=orders'
+    )
+
+    void 'otel resource attributes are attached to exported spans'() {
+        given:
+        InMemorySpanExporter spanExporter = context.getBean(InMemorySpanExporter)
+        OpenTelemetry openTelemetry = context.getBean(OpenTelemetry)
+
+        when:
+        String configuredResourceAttributes = context.getProperty('otel.resource.attributes', String).orElse(null)
+        def span = openTelemetry.getTracer('test').spanBuilder('test-span').startSpan()
+        span.end()
+
+        then:
+        configuredResourceAttributes == 'deployment.environment=test,service.namespace=orders'
+        spanExporter.finishedSpanItems.size() == 1
+        spanExporter.finishedSpanItems[0].resource.getAttribute(AttributeKey.stringKey('deployment.environment')) == 'test'
+        spanExporter.finishedSpanItems[0].resource.getAttribute(AttributeKey.stringKey('service.namespace')) == 'orders'
+        spanExporter.finishedSpanItems[0].resource.getAttribute(AttributeKey.stringKey('provider.attribute')) == 'custom'
+
+        cleanup:
+        spanExporter.reset()
+    }
+
+    @Requires(property = 'spec.name', value = 'OpenTelemetryResourceAttributesSpec')
+    @Factory
+    static class TestFactory {
+
+        @Singleton
+        SpanProcessor spanProcessor(InMemorySpanExporter spanExporter) {
+            SimpleSpanProcessor.create(spanExporter)
+        }
+
+        @Singleton
+        InMemorySpanExporter inMemorySpanExporter() {
+            InMemorySpanExporter.create()
+        }
+
+        @Singleton
+        ResourceProvider resourceProvider() {
+            () -> Resource.create(Attributes.of(AttributeKey.stringKey('provider.attribute'), 'custom'))
+        }
+    }
+}

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/OpenTelemetryResourceAttributesSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/OpenTelemetryResourceAttributesSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.tracing.opentelemetry
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.PropertySource
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributeKey
@@ -11,19 +12,16 @@ import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import jakarta.inject.Singleton
-import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 class OpenTelemetryResourceAttributesSpec extends Specification {
 
-    @AutoCleanup
-    ApplicationContext context = ApplicationContext.run(
-            'spec.name': 'OpenTelemetryResourceAttributesSpec',
-            'otel.resource.attributes': 'deployment.environment=test,service.namespace=orders'
-    )
-
-    void 'otel resource attributes are attached to exported spans'() {
+    void 'otel resource attributes from #sourceName are attached to exported spans'() {
         given:
+        ApplicationContext context = ApplicationContext.builder()
+                .properties('spec.name': 'OpenTelemetryResourceAttributesSpec')
+                .propertySources(propertySource)
+                .start()
         InMemorySpanExporter spanExporter = context.getBean(InMemorySpanExporter)
         OpenTelemetry openTelemetry = context.getBean(OpenTelemetry)
 
@@ -41,6 +39,12 @@ class OpenTelemetryResourceAttributesSpec extends Specification {
 
         cleanup:
         spanExporter.reset()
+        context.close()
+
+        where:
+        sourceName            | propertySource
+        'Micronaut property'  | PropertySource.of('test-properties', ['otel.resource.attributes': 'deployment.environment=test,service.namespace=orders'])
+        'environment variable' | PropertySource.of('test-environment', ['OTEL_RESOURCE_ATTRIBUTES': 'deployment.environment=test,service.namespace=orders'], PropertySource.PropertyConvention.ENVIRONMENT_VARIABLE, null)
     }
 
     @Requires(property = 'spec.name', value = 'OpenTelemetryResourceAttributesSpec')


### PR DESCRIPTION
## Summary
- preserve standard OpenTelemetry resource configuration, including `otel.resource.attributes` and `OTEL_RESOURCE_ATTRIBUTES`, when Micronaut creates the SDK
- merge configured environment resource attributes with any Micronaut `ResourceProvider` contribution instead of overwriting them
- add focused OpenTelemetry coverage and document the supported resource attribute configuration

## Verification
- `./gradlew --no-daemon :micronaut-tracing-opentelemetry:test --tests '*OpenTelemetryResourceAttributesSpec'`

Resolves #488
