### PR TITLE
Finish server spans after response filters

### DIFF
--- a/src/main/docs/guide/opentelemetry/http.adoc
+++ b/src/main/docs/guide/opentelemetry/http.adoc
@@ -1,6 +1,17 @@
 To enable creating span objects on the every HTTP server request, client request, server response and client response you have to add next depedency:
 dependency:micronaut-tracing-opentelemetry-http[scope="implementation", groupId="io.micronaut.tracing"]
 
+== Ordering custom server filters
+
+OpenTelemetry HTTP server tracing runs in the Micronaut `ServerFilterPhase.TRACING` phase.
+If a custom server filter reads from or writes to the current OpenTelemetry span, order the filter after the tracing phase so the server span is already current.
+
+`@Order` values must be compile-time constants, so use `Ordered` when you want to refer to `ServerFilterPhase.TRACING.after()` directly:
+
+[source, java]
+----
+include::tracing-opentelemetry-http/src/test/java/io/micronaut/tracing/opentelemetry/instrument/http/OrderedTracingServerFilter.java[]
+----
 
 == Filtering HTTP spans
 

--- a/src/main/docs/guide/opentelemetry/http.adoc
+++ b/src/main/docs/guide/opentelemetry/http.adoc
@@ -4,7 +4,7 @@ dependency:micronaut-tracing-opentelemetry-http[scope="implementation", groupId=
 == Ordering custom server filters
 
 OpenTelemetry HTTP server tracing runs in the Micronaut `ServerFilterPhase.TRACING` phase.
-If a custom server filter reads from or writes to the current OpenTelemetry span, order the filter after the tracing phase so the server span is already current.
+If a custom server filter reads from or writes to the current OpenTelemetry span, order the filter after the tracing phase so the server span is already current in request and response filters.
 
 `@Order` values must be compile-time constants, so use `Ordered` when you want to refer to `ServerFilterPhase.TRACING.after()` directly:
 

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -27,6 +27,8 @@ import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.tracing.opentelemetry.OpenTelemetryPropagationContext;
 import io.micronaut.tracing.opentelemetry.instrument.util.OpenTelemetryExclusionsConfiguration;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -97,8 +99,18 @@ public final class OpenTelemetryServerFilter implements HttpServerFilter {
             .propagate()) {
             var propagatedContext = PropagatedContext.get();
             return Mono.from(chain.proceed(request))
+                .doOnError(throwable -> onError(request, context, throwable))
                 .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
         }
+    }
+
+    private void onError(HttpRequest<?> request, Context context, Throwable e) {
+        Span.fromContext(context)
+            .setStatus(StatusCode.ERROR)
+            .recordException(e);
+        instrumenter.end(context, request, null, e);
+        request.setAttribute(OpenTelemetryServerResponseFilter.FINISHED, true);
+        request.setAttribute(CONTINUE, true);
     }
 
     private boolean shouldExclude(@Nullable String path) {

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -36,6 +36,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.function.Predicate;
 
+import static io.micronaut.http.filter.ServerFilterPhase.TRACING;
 import static io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTelemetryFilter.SERVER_PATH;
 
 /**
@@ -70,7 +71,7 @@ public final class OpenTelemetryServerFilter implements HttpServerFilter {
 
     @Override
     public int getOrder() {
-        return -1000;
+        return TRACING.order();
     }
 
     @Override

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -27,10 +27,7 @@ import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.tracing.opentelemetry.OpenTelemetryPropagationContext;
-import io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTelemetryFilter;
 import io.micronaut.tracing.opentelemetry.instrument.util.OpenTelemetryExclusionsConfiguration;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -38,8 +35,9 @@ import jakarta.inject.Named;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
-import static io.micronaut.http.filter.ServerFilterPhase.TRACING;
-import static io.micronaut.tracing.opentelemetry.instrument.http.server.OpenTelemetryServerFilter.SERVER_PATH;
+import java.util.function.Predicate;
+
+import static io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTelemetryFilter.SERVER_PATH;
 
 /**
  * An HTTP server instrumentation filter that uses Open Telemetry.
@@ -50,12 +48,15 @@ import static io.micronaut.tracing.opentelemetry.instrument.http.server.OpenTele
 @Internal
 @Filter(SERVER_PATH)
 @Requires(beans = Tracer.class)
-public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter implements HttpServerFilter {
+public final class OpenTelemetryServerFilter implements HttpServerFilter {
 
     private static final String APPLIED = OpenTelemetryServerFilter.class.getName() + "-applied";
     private static final String CONTINUE = OpenTelemetryServerFilter.class.getName() + "-continue";
+    static final String CONTEXT = OpenTelemetryServerFilter.class.getName() + "-context";
 
     private final Instrumenter<HttpRequest<?>, Object> instrumenter;
+    @Nullable
+    private final Predicate<String> pathExclusionTest;
 
     /**
      * @param exclusionsConfig The {@link OpenTelemetryExclusionsConfiguration}
@@ -63,14 +64,13 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
      */
     public OpenTelemetryServerFilter(@Nullable OpenTelemetryExclusionsConfiguration exclusionsConfig,
                                      @Named("micronautHttpServerTelemetryInstrumenter") Instrumenter<HttpRequest<?>, Object> instrumenter) {
-        super(exclusionsConfig == null ? null : exclusionsConfig.exclusionTest());
-
+        this.pathExclusionTest = exclusionsConfig == null ? null : exclusionsConfig.exclusionTest();
         this.instrumenter = instrumenter;
     }
 
     @Override
     public int getOrder() {
-        return TRACING.order();
+        return -1000;
     }
 
     @Override
@@ -90,35 +90,17 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
         }
 
         Context context = instrumenter.start(parentContext, request);
-
+        request.setAttribute(CONTEXT, context);
         try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
             .plus(new OpenTelemetryPropagationContext(context))
             .propagate()) {
-
             var propagatedContext = PropagatedContext.get();
             return Mono.from(chain.proceed(request))
-                .doOnNext(mutableHttpResponse -> mutableHttpResponse.getAttribute(HttpAttributes.EXCEPTION, Exception.class)
-                    .ifPresentOrElse(
-                        e -> onError(request, context, mutableHttpResponse, e), () -> {
-                            if (mutableHttpResponse.status().getCode() >= 400) {
-                                onError(request, context, mutableHttpResponse, null);
-                            } else {
-                                instrumenter.end(context, request, mutableHttpResponse, null);
-                            }
-                        }))
-                .doOnError(throwable -> onError(request, context, null, throwable))
                 .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
         }
     }
 
-    private void onError(HttpRequest<?> request, Context context,
-                         @Nullable MutableHttpResponse<?> mutableHttpResponse, @Nullable Throwable e) {
-        var span = Span.fromContext(context)
-            .setStatus(StatusCode.ERROR);
-        if (e != null) {
-            span.recordException(e);
-        }
-        instrumenter.end(context, request, mutableHttpResponse, e);
-        request.setAttribute(CONTINUE, true);
+    private boolean shouldExclude(@Nullable String path) {
+        return pathExclusionTest != null && path != null && pathExclusionTest.test(path);
     }
 }

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -20,7 +20,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
@@ -50,13 +49,14 @@ import static io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTel
 @Requires(beans = Tracer.class)
 public final class OpenTelemetryServerFilter implements HttpServerFilter {
 
-    private static final String APPLIED = OpenTelemetryServerFilter.class.getName() + "-applied";
-    private static final String CONTINUE = OpenTelemetryServerFilter.class.getName() + "-continue";
     static final String CONTEXT = OpenTelemetryServerFilter.class.getName() + "-context";
 
-    private final Instrumenter<HttpRequest<?>, Object> instrumenter;
+    private static final String APPLIED = OpenTelemetryServerFilter.class.getName() + "-applied";
+    private static final String CONTINUE = OpenTelemetryServerFilter.class.getName() + "-continue";
+
     @Nullable
     private final Predicate<String> pathExclusionTest;
+    private final Instrumenter<HttpRequest<?>, Object> instrumenter;
 
     /**
      * @param exclusionsConfig The {@link OpenTelemetryExclusionsConfiguration}

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerResponseFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerResponseFilter.java
@@ -28,6 +28,7 @@ import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.tracing.opentelemetry.OpenTelemetryPropagationContext;
 import io.micronaut.web.router.RouteAttributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -48,7 +49,7 @@ import static io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTel
 @Requires(beans = Tracer.class)
 final class OpenTelemetryServerRequestContextFilter implements Ordered {
 
-    private static final int ORDER_OFFSET = 100;
+    private static final int ORDER_STEP = 1;
 
     @RequestFilter
     void propagateRequestContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
@@ -60,7 +61,7 @@ final class OpenTelemetryServerRequestContextFilter implements Ordered {
 
     @Override
     public int getOrder() {
-        return TRACING.after() - ORDER_OFFSET;
+        return TRACING.after() - ORDER_STEP;
     }
 }
 
@@ -69,7 +70,7 @@ final class OpenTelemetryServerRequestContextFilter implements Ordered {
 @Requires(beans = Tracer.class)
 final class OpenTelemetryServerResponseContextFilter implements Ordered {
 
-    private static final int ORDER_OFFSET = 100;
+    private static final int ORDER_STEP = 1;
 
     @ResponseFilter
     void propagateResponseContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
@@ -81,7 +82,7 @@ final class OpenTelemetryServerResponseContextFilter implements Ordered {
 
     @Override
     public int getOrder() {
-        return TRACING.after() + ORDER_OFFSET;
+        return TRACING.after() + ORDER_STEP;
     }
 }
 
@@ -90,7 +91,7 @@ final class OpenTelemetryServerResponseContextFilter implements Ordered {
 @Requires(beans = Tracer.class)
 final class OpenTelemetryServerResponseFilter implements Ordered {
 
-    private static final String FINISHED = OpenTelemetryServerResponseFilter.class.getName() + "-finished";
+    static final String FINISHED = OpenTelemetryServerResponseFilter.class.getName() + "-finished";
 
     private final Instrumenter<HttpRequest<?>, Object> instrumenter;
 
@@ -123,8 +124,10 @@ final class OpenTelemetryServerResponseFilter implements Ordered {
                          HttpRequest<?> request,
                          @Nullable MutableHttpResponse<?> response,
                          @Nullable Throwable e) {
+        Span span = Span.fromContext(context)
+            .setStatus(StatusCode.ERROR);
         if (e != null) {
-            Span.fromContext(context).recordException(e);
+            span.recordException(e);
         }
         instrumenter.end(context, request, response, e);
     }

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerResponseFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerResponseFilter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.instrument.http.server;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.propagation.MutablePropagatedContext;
+import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.annotation.ResponseFilter;
+import io.micronaut.http.annotation.ServerFilter;
+import io.micronaut.tracing.opentelemetry.OpenTelemetryPropagationContext;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import jakarta.inject.Named;
+
+import static io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTelemetryFilter.SERVER_PATH;
+
+/**
+ * Response hooks for HTTP server tracing that keep the span current for user response filters and
+ * finish it after those filters run.
+ *
+ * @author Nemanja Mikic
+ * @since 4.2.0
+ */
+@Internal
+@ServerFilter(SERVER_PATH)
+@Requires(beans = Tracer.class)
+final class OpenTelemetryServerResponseFilter {
+
+    private static final int RESPONSE_CONTEXT_ORDER = 1;
+    private static final int REQUEST_CONTEXT_ORDER = -999;
+    private static final int FINISH_ORDER = -1000;
+    private static final String FINISHED = OpenTelemetryServerResponseFilter.class.getName() + "-finished";
+
+    private final Instrumenter<HttpRequest<?>, Object> instrumenter;
+
+    OpenTelemetryServerResponseFilter(@Named("micronautHttpServerTelemetryInstrumenter") Instrumenter<HttpRequest<?>, Object> instrumenter) {
+        this.instrumenter = instrumenter;
+    }
+
+    @RequestFilter
+    @Order(REQUEST_CONTEXT_ORDER)
+    void propagateRequestContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
+        Context context = request.getAttribute(OpenTelemetryServerFilter.CONTEXT, Context.class).orElse(null);
+        if (context != null) {
+            propagatedContext.add(new OpenTelemetryPropagationContext(context));
+        }
+    }
+
+    @ResponseFilter
+    @Order(RESPONSE_CONTEXT_ORDER)
+    void propagateResponseContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
+        Context context = request.getAttribute(OpenTelemetryServerFilter.CONTEXT, Context.class).orElse(null);
+        if (context != null) {
+            propagatedContext.add(new OpenTelemetryPropagationContext(context));
+        }
+    }
+
+    @ResponseFilter
+    @Order(FINISH_ORDER)
+    void finishResponse(HttpRequest<?> request, MutableHttpResponse<?> response) {
+        if (request.getAttribute(FINISHED, Boolean.class).orElse(false)) {
+            return;
+        }
+        Context context = request.getAttribute(OpenTelemetryServerFilter.CONTEXT, Context.class).orElse(null);
+        if (context == null) {
+            return;
+        }
+        request.setAttribute(FINISHED, true);
+        response.getAttribute(HttpAttributes.EXCEPTION, Exception.class)
+            .ifPresentOrElse(
+                e -> onError(context, request, response, e), () -> {
+                    if (response.status().getCode() >= 400) {
+                        onError(context, request, response, null);
+                    } else {
+                        instrumenter.end(context, request, response, null);
+                    }
+                });
+    }
+
+    private void onError(Context context,
+                         HttpRequest<?> request,
+                         @Nullable MutableHttpResponse<?> response,
+                         @Nullable Throwable e) {
+        var span = Span.fromContext(context)
+            .setStatus(StatusCode.ERROR);
+        if (e != null) {
+            span.recordException(e);
+        }
+        instrumenter.end(context, request, response, e);
+    }
+}

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerResponseFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerResponseFilter.java
@@ -18,22 +18,22 @@ package io.micronaut.tracing.opentelemetry.instrument.http.server;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.propagation.MutablePropagatedContext;
-import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.tracing.opentelemetry.OpenTelemetryPropagationContext;
+import io.micronaut.web.router.RouteAttributes;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import jakarta.inject.Named;
 
+import static io.micronaut.http.filter.ServerFilterPhase.TRACING;
 import static io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTelemetryFilter.SERVER_PATH;
 
 /**
@@ -46,11 +46,50 @@ import static io.micronaut.tracing.opentelemetry.instrument.http.AbstractOpenTel
 @Internal
 @ServerFilter(SERVER_PATH)
 @Requires(beans = Tracer.class)
-final class OpenTelemetryServerResponseFilter {
+final class OpenTelemetryServerRequestContextFilter implements Ordered {
 
-    private static final int RESPONSE_CONTEXT_ORDER = 1;
-    private static final int REQUEST_CONTEXT_ORDER = -999;
-    private static final int FINISH_ORDER = -1000;
+    private static final int ORDER_OFFSET = 100;
+
+    @RequestFilter
+    void propagateRequestContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
+        Context context = request.getAttribute(OpenTelemetryServerFilter.CONTEXT, Context.class).orElse(null);
+        if (context != null) {
+            propagatedContext.add(new OpenTelemetryPropagationContext(context));
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return TRACING.after() - ORDER_OFFSET;
+    }
+}
+
+@Internal
+@ServerFilter(SERVER_PATH)
+@Requires(beans = Tracer.class)
+final class OpenTelemetryServerResponseContextFilter implements Ordered {
+
+    private static final int ORDER_OFFSET = 100;
+
+    @ResponseFilter
+    void propagateResponseContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
+        Context context = request.getAttribute(OpenTelemetryServerFilter.CONTEXT, Context.class).orElse(null);
+        if (context != null) {
+            propagatedContext.add(new OpenTelemetryPropagationContext(context));
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return TRACING.after() + ORDER_OFFSET;
+    }
+}
+
+@Internal
+@ServerFilter(SERVER_PATH)
+@Requires(beans = Tracer.class)
+final class OpenTelemetryServerResponseFilter implements Ordered {
+
     private static final String FINISHED = OpenTelemetryServerResponseFilter.class.getName() + "-finished";
 
     private final Instrumenter<HttpRequest<?>, Object> instrumenter;
@@ -59,26 +98,7 @@ final class OpenTelemetryServerResponseFilter {
         this.instrumenter = instrumenter;
     }
 
-    @RequestFilter
-    @Order(REQUEST_CONTEXT_ORDER)
-    void propagateRequestContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
-        Context context = request.getAttribute(OpenTelemetryServerFilter.CONTEXT, Context.class).orElse(null);
-        if (context != null) {
-            propagatedContext.add(new OpenTelemetryPropagationContext(context));
-        }
-    }
-
     @ResponseFilter
-    @Order(RESPONSE_CONTEXT_ORDER)
-    void propagateResponseContext(HttpRequest<?> request, MutablePropagatedContext propagatedContext) {
-        Context context = request.getAttribute(OpenTelemetryServerFilter.CONTEXT, Context.class).orElse(null);
-        if (context != null) {
-            propagatedContext.add(new OpenTelemetryPropagationContext(context));
-        }
-    }
-
-    @ResponseFilter
-    @Order(FINISH_ORDER)
     void finishResponse(HttpRequest<?> request, MutableHttpResponse<?> response) {
         if (request.getAttribute(FINISHED, Boolean.class).orElse(false)) {
             return;
@@ -88,7 +108,7 @@ final class OpenTelemetryServerResponseFilter {
             return;
         }
         request.setAttribute(FINISHED, true);
-        response.getAttribute(HttpAttributes.EXCEPTION, Exception.class)
+        RouteAttributes.getException(response)
             .ifPresentOrElse(
                 e -> onError(context, request, response, e), () -> {
                     if (response.status().getCode() >= 400) {
@@ -103,11 +123,14 @@ final class OpenTelemetryServerResponseFilter {
                          HttpRequest<?> request,
                          @Nullable MutableHttpResponse<?> response,
                          @Nullable Throwable e) {
-        var span = Span.fromContext(context)
-            .setStatus(StatusCode.ERROR);
         if (e != null) {
-            span.recordException(e);
+            Span.fromContext(context).recordException(e);
         }
         instrumenter.end(context, request, response, e);
+    }
+
+    @Override
+    public int getOrder() {
+        return TRACING.order();
     }
 }

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.core.order.Ordered
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -542,7 +543,7 @@ class OpenTelemetryHttpSpec extends Specification {
         }
 
         @ResponseFilter
-        void traceResponse(HttpRequest<?> request, HttpResponse<?> response) {
+        void traceResponse(HttpRequest<?> request, MutableHttpResponse<?> response) {
             response.headers.add('X-Request-Filter-Recording', request.getAttribute('request-filter-recording', String).orElse('missing'))
             response.headers.add('X-Response-Filter-Recording', Boolean.toString(Span.current().isRecording()))
             Span.current().setAttribute('response-filter', 'recorded')

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.async.annotation.SingleResult
+import io.micronaut.core.order.Ordered
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -53,6 +54,8 @@ import spock.util.concurrent.PollingConditions
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import io.micronaut.scheduling.TaskExecutors
+
+import static io.micronaut.http.filter.ServerFilterPhase.TRACING
 
 @Slf4j("LOG")
 class OpenTelemetryHttpSpec extends Specification {
@@ -531,7 +534,7 @@ class OpenTelemetryHttpSpec extends Specification {
     }
 
     @ServerFilter('/filters/**')
-    static class FilterSpanServerFilter {
+    static class FilterSpanServerFilter implements Ordered {
         @RequestFilter
         void traceRequest(HttpRequest<?> request) {
             request.setAttribute('request-filter-recording', Boolean.toString(Span.current().isRecording()))
@@ -543,6 +546,11 @@ class OpenTelemetryHttpSpec extends Specification {
             response.headers.add('X-Request-Filter-Recording', request.getAttribute('request-filter-recording', String).orElse('missing'))
             response.headers.add('X-Response-Filter-Recording', Boolean.toString(Span.current().isRecording()))
             Span.current().setAttribute('response-filter', 'recorded')
+        }
+
+        @Override
+        int getOrder() {
+            TRACING.after()
         }
     }
 

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -471,6 +471,69 @@ class OpenTelemetryHttpSpec extends Specification {
         exporter.reset()
     }
 
+    void 'response filter with throwable can record to the current server span after controller throws'() {
+        def internalSpanCount = 0
+        def serverSpanCount = 1
+        def clientSpanCount = 0
+
+        when:
+        reactorHttpClient.toBlocking().exchange('/filters/throwing', String)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.INTERNAL_SERVER_ERROR
+        e.response.header('X-Request-Filter-Recording') == 'true'
+        e.response.header('X-Response-Filter-Recording') == 'true'
+        e.response.header('X-Response-Filter-Throwable') == 'false'
+
+        and:
+        conditions.eventually {
+            hasSpans(internalSpanCount, serverSpanCount, clientSpanCount)
+            def serverSpans = exporter.finishedSpanItems.findAll { it.kind == SpanKind.SERVER }
+            serverSpans.size() == 1
+            def serverSpan = serverSpans[0]
+            serverSpan.status.statusCode == StatusCode.ERROR
+            serverSpan.events.any { it.name == 'exception' }
+            serverSpan.attributes.get(AttributeKey.stringKey('response-filter')) == 'recorded'
+            serverSpan.attributes.get(AttributeKey.stringKey('response-filter-throwable')) == 'none'
+            hasHttpSemanticAttributes(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+
+        cleanup:
+        exporter.reset()
+    }
+
+    void 'response filter can record to the current server span for error responses'() {
+        def internalSpanCount = 0
+        def serverSpanCount = 1
+        def clientSpanCount = 0
+
+        when:
+        reactorHttpClient.toBlocking().exchange('/filters/bad-request', String)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.BAD_REQUEST
+        e.response.header('X-Request-Filter-Recording') == 'true'
+        e.response.header('X-Response-Filter-Recording') == 'true'
+        e.response.header('X-Response-Filter-Throwable') == 'false'
+
+        and:
+        conditions.eventually {
+            hasSpans(internalSpanCount, serverSpanCount, clientSpanCount)
+            def serverSpans = exporter.finishedSpanItems.findAll { it.kind == SpanKind.SERVER }
+            serverSpans.size() == 1
+            def serverSpan = serverSpans[0]
+            serverSpan.status.statusCode == StatusCode.ERROR
+            serverSpan.attributes.get(AttributeKey.stringKey('response-filter')) == 'recorded'
+            serverSpan.attributes.get(AttributeKey.stringKey('response-filter-throwable')) == 'none'
+            hasHttpSemanticAttributes(HttpStatus.BAD_REQUEST)
+        }
+
+        cleanup:
+        exporter.reset()
+    }
+
     void 'test consecutive sibling client calls'() {
         def internalSpanCount = 0
         def serverSpanCount = 3
@@ -532,6 +595,16 @@ class OpenTelemetryHttpSpec extends Specification {
         String recording() {
             'ok'
         }
+
+        @Get('/throwing')
+        String throwing() {
+            throw new RuntimeException('filter failure')
+        }
+
+        @Get('/bad-request')
+        MutableHttpResponse<String> badRequest() {
+            HttpResponse.badRequest('bad request')
+        }
     }
 
     @ServerFilter('/filters/**')
@@ -543,10 +616,12 @@ class OpenTelemetryHttpSpec extends Specification {
         }
 
         @ResponseFilter
-        void traceResponse(HttpRequest<?> request, MutableHttpResponse<?> response) {
+        void traceResponse(HttpRequest<?> request, MutableHttpResponse<?> response, @Nullable Throwable throwable) {
             response.headers.add('X-Request-Filter-Recording', request.getAttribute('request-filter-recording', String).orElse('missing'))
             response.headers.add('X-Response-Filter-Recording', Boolean.toString(Span.current().isRecording()))
+            response.headers.add('X-Response-Filter-Throwable', Boolean.toString(throwable != null))
             Span.current().setAttribute('response-filter', 'recorded')
+            Span.current().setAttribute('response-filter-throwable', throwable == null ? 'none' : throwable.class.simpleName)
         }
 
         @Override

--- a/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
+++ b/tracing-opentelemetry-http/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/http/OpenTelemetryHttpSpec.groovy
@@ -15,6 +15,9 @@ import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.PathVariable
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.annotation.RequestFilter
+import io.micronaut.http.annotation.ResponseFilter
+import io.micronaut.http.annotation.ServerFilter
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
@@ -439,6 +442,31 @@ class OpenTelemetryHttpSpec extends Specification {
         exporter.reset()
     }
 
+    void 'response filters can record to the current server span'() {
+        def internalSpanCount = 0
+        def serverSpanCount = 1
+        def clientSpanCount = 0
+
+        when:
+        HttpResponse<String> response = reactorHttpClient.toBlocking().exchange('/filters/recording', String)
+
+        then:
+        response.body() == 'ok'
+        response.header('X-Request-Filter-Recording') == 'true'
+        response.header('X-Response-Filter-Recording') == 'true'
+
+        and:
+        conditions.eventually {
+            hasSpans(internalSpanCount, serverSpanCount, clientSpanCount)
+            exporter.finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey('request-filter')) == 'recorded')
+            exporter.finishedSpanItems.attributes.stream().anyMatch(x -> x.get(AttributeKey.stringKey('response-filter')) == 'recorded')
+            hasHttpSemanticAttributes(HttpStatus.OK)
+        }
+
+        cleanup:
+        exporter.reset()
+    }
+
     void 'test consecutive sibling client calls'() {
         def internalSpanCount = 0
         def serverSpanCount = 3
@@ -490,6 +518,31 @@ class OpenTelemetryHttpSpec extends Specification {
         Mono<String> quadrupleWords(@QueryValue String input) {
             downstreamClient.doubleWords(input)
                     .flatMap { resp -> downstreamClient.doubleWords(resp) }
+        }
+    }
+
+    @Controller('/filters')
+    static class FilterSpanController {
+
+        @Get('/recording')
+        String recording() {
+            'ok'
+        }
+    }
+
+    @ServerFilter('/filters/**')
+    static class FilterSpanServerFilter {
+        @RequestFilter
+        void traceRequest(HttpRequest<?> request) {
+            request.setAttribute('request-filter-recording', Boolean.toString(Span.current().isRecording()))
+            Span.current().setAttribute('request-filter', 'recorded')
+        }
+
+        @ResponseFilter
+        void traceResponse(HttpRequest<?> request, HttpResponse<?> response) {
+            response.headers.add('X-Request-Filter-Recording', request.getAttribute('request-filter-recording', String).orElse('missing'))
+            response.headers.add('X-Response-Filter-Recording', Boolean.toString(Span.current().isRecording()))
+            Span.current().setAttribute('response-filter', 'recorded')
         }
     }
 

--- a/tracing-opentelemetry-http/src/test/java/io/micronaut/tracing/opentelemetry/instrument/http/OrderedTracingServerFilter.java
+++ b/tracing-opentelemetry-http/src/test/java/io/micronaut/tracing/opentelemetry/instrument/http/OrderedTracingServerFilter.java
@@ -2,7 +2,9 @@ package io.micronaut.tracing.opentelemetry.instrument.http;
 
 import io.micronaut.core.order.Ordered;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.opentelemetry.api.trace.Span;
 
@@ -14,6 +16,11 @@ final class OrderedTracingServerFilter implements Ordered {
     @RequestFilter
     void traceRequest(HttpRequest<?> request) {
         Span.current().setAttribute("example.attribute", "value");
+    }
+
+    @ResponseFilter
+    void traceResponse(HttpRequest<?> request, MutableHttpResponse<?> response) {
+        Span.current().setAttribute("example.response.attribute", "value");
     }
 
     @Override

--- a/tracing-opentelemetry-http/src/test/java/io/micronaut/tracing/opentelemetry/instrument/http/OrderedTracingServerFilter.java
+++ b/tracing-opentelemetry-http/src/test/java/io/micronaut/tracing/opentelemetry/instrument/http/OrderedTracingServerFilter.java
@@ -1,0 +1,23 @@
+package io.micronaut.tracing.opentelemetry.instrument.http;
+
+import io.micronaut.core.order.Ordered;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.annotation.ServerFilter;
+import io.opentelemetry.api.trace.Span;
+
+import static io.micronaut.http.filter.ServerFilterPhase.TRACING;
+
+@ServerFilter("/api/**")
+final class OrderedTracingServerFilter implements Ordered {
+
+    @RequestFilter
+    void traceRequest(HttpRequest<?> request) {
+        Span.current().setAttribute("example.attribute", "value");
+    }
+
+    @Override
+    public int getOrder() {
+        return TRACING.after();
+    }
+}


### PR DESCRIPTION
## Summary
- finish HTTP server spans after response filters run
- use Micronaut ServerFilterPhase ordering for OpenTelemetry server filters instead of hard-coded order values
- document that custom server filters should implement Ordered and return TRACING.after() when they need the current OpenTelemetry span
- add a regression test and source-backed docs example for request and response filters recording to the current server span

## Verification
- ./gradlew :micronaut-tracing-opentelemetry-http:test --tests io.micronaut.tracing.opentelemetry.instrument.http.OpenTelemetryHttpSpec
- ./gradlew :micronaut-tracing-opentelemetry-http:check -x test
- ./gradlew publishGuide docs

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/816
