### PR TITLE
Fix Kafka consumer tracing context

### DIFF
--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetry.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetry.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetry.java
@@ -254,13 +254,13 @@ public final class KafkaTelemetry {
         }
     }
 
-    <K, V> ConsumerRecordContext startConsumerRecordSpan(ConsumerRecord<K, V> record, Consumer<K, V> consumer) {
-        return startConsumerRecordSpan(record, KafkaUtil.getConsumerGroup(consumer), KafkaUtil.getClientId(consumer));
+    <K, V> ConsumerRecordContext startConsumerRecordSpan(ConsumerRecord<K, V> consumerRecord, Consumer<K, V> consumer) {
+        return startConsumerRecordSpan(consumerRecord, KafkaUtil.getConsumerGroup(consumer), KafkaUtil.getClientId(consumer));
     }
 
-    <K, V> ConsumerRecordContext startConsumerRecordSpan(ConsumerRecord<K, V> record, String consumerGroup, String clientId) {
+    <K, V> ConsumerRecordContext startConsumerRecordSpan(ConsumerRecord<K, V> consumerRecord, String consumerGroup, String clientId) {
         Context parentContext = Context.current();
-        KafkaProcessRequest request = KafkaProcessRequest.create(record, consumerGroup, clientId);
+        KafkaProcessRequest request = KafkaProcessRequest.create(consumerRecord, consumerGroup, clientId);
         if (!consumerProcessInstrumenter.shouldStart(parentContext, request)) {
             return null;
         }

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetry.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetry.java
@@ -254,6 +254,23 @@ public final class KafkaTelemetry {
         }
     }
 
+    <K, V> ConsumerRecordContext startConsumerRecordSpan(ConsumerRecord<K, V> record, Consumer<K, V> consumer) {
+        return startConsumerRecordSpan(record, KafkaUtil.getConsumerGroup(consumer), KafkaUtil.getClientId(consumer));
+    }
+
+    <K, V> ConsumerRecordContext startConsumerRecordSpan(ConsumerRecord<K, V> record, String consumerGroup, String clientId) {
+        Context parentContext = Context.current();
+        KafkaProcessRequest request = KafkaProcessRequest.create(record, consumerGroup, clientId);
+        if (!consumerProcessInstrumenter.shouldStart(parentContext, request)) {
+            return null;
+        }
+        return new ConsumerRecordContext(request, consumerProcessInstrumenter.start(parentContext, request));
+    }
+
+    void endConsumerRecordSpan(ConsumerRecordContext consumerRecordContext) {
+        consumerProcessInstrumenter.end(consumerRecordContext.context(), consumerRecordContext.request(), null, null);
+    }
+
     private <K, V> void processConsumerRecord(Context parentContext, ConsumerRecord<K, V> record, String consumerGroup, String clientId) {
         KafkaProcessRequest request = KafkaProcessRequest.create(record, consumerGroup, clientId);
         if (!consumerProcessInstrumenter.shouldStart(parentContext, request)) {
@@ -345,6 +362,9 @@ public final class KafkaTelemetry {
 
     public KafkaTelemetryConfiguration getKafkaTelemetryProperties() {
         return kafkaTelemetryConfiguration;
+    }
+
+    record ConsumerRecordContext(KafkaProcessRequest request, Context context) {
     }
 
     private final class ProducerCallback implements Callback {

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
@@ -16,6 +16,7 @@
 package io.micronaut.tracing.opentelemetry.instrument.kafka;
 
 import io.micronaut.core.annotation.Internal;
+import io.opentelemetry.context.Scope;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -34,12 +35,16 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.metrics.KafkaMetric;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 /**
@@ -54,6 +59,7 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
 
     private final Consumer<K, V> consumer;
     private final KafkaTelemetry kafkaTelemetry;
+    private ActiveRecordContext activeRecordContext;
 
     public MicronautOtelKafkaConsumer(Consumer<K, V> consumer, KafkaTelemetry kafkaTelemetry) {
         this.consumer = consumer;
@@ -62,270 +68,343 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Set<TopicPartition> assignment() {
-        return consumer.assignment();
+        return withInactiveContext(consumer::assignment);
     }
 
     @Override
     public Set<String> subscription() {
-        return consumer.subscription();
+        return withInactiveContext(consumer::subscription);
     }
 
     @Override
     public void subscribe(Collection<String> collection) {
-        consumer.subscribe(collection);
+        runWithInactiveContext(() -> consumer.subscribe(collection));
     }
 
     @Override
     public void subscribe(Collection<String> collection, ConsumerRebalanceListener consumerRebalanceListener) {
-        consumer.subscribe(collection, consumerRebalanceListener);
-
+        runWithInactiveContext(() -> consumer.subscribe(collection, consumerRebalanceListener));
     }
 
     @Override
     public void assign(Collection<TopicPartition> collection) {
-        consumer.assign(collection);
+        runWithInactiveContext(() -> consumer.assign(collection));
     }
 
     @Override
     public void subscribe(Pattern pattern, ConsumerRebalanceListener consumerRebalanceListener) {
-        consumer.subscribe(pattern, consumerRebalanceListener);
+        runWithInactiveContext(() -> consumer.subscribe(pattern, consumerRebalanceListener));
     }
 
     @Override
     public void subscribe(Pattern pattern) {
-        consumer.subscribe(pattern);
+        runWithInactiveContext(() -> consumer.subscribe(pattern));
     }
 
     @Override
     public void subscribe(SubscriptionPattern subscriptionPattern, ConsumerRebalanceListener consumerRebalanceListener) {
-        consumer.subscribe(subscriptionPattern, consumerRebalanceListener);
+        runWithInactiveContext(() -> consumer.subscribe(subscriptionPattern, consumerRebalanceListener));
     }
 
     @Override
     public void subscribe(SubscriptionPattern subscriptionPattern) {
-        consumer.subscribe(subscriptionPattern);
+        runWithInactiveContext(() -> consumer.subscribe(subscriptionPattern));
     }
 
     @Override
     public void unsubscribe() {
-        consumer.unsubscribe();
+        runWithInactiveContext(consumer::unsubscribe);
     }
 
     @Override
     public ConsumerRecords<K, V> poll(Duration duration) {
-        ConsumerRecords<K, V> records = consumer.poll(duration);
-        traceConsumerRecords(records);
-        return records;
+        return withInactiveContext(() -> traceConsumerRecords(consumer.poll(duration)));
     }
 
-    private void traceConsumerRecords(ConsumerRecords<K, V> consumerRecords) {
-        List<ConsumerRecord<K, V>> recordsToTrace = new ArrayList<>();
-        for (ConsumerRecord<K, V> record : consumerRecords) {
-            if (kafkaTelemetry.excludeTopic(record.topic()) || !kafkaTelemetry.filterConsumerRecord(record, consumer)) {
-                continue;
-            }
-            recordsToTrace.add(record);
+    private ConsumerRecords<K, V> traceConsumerRecords(ConsumerRecords<K, V> consumerRecords) {
+        if (consumerRecords == null || consumerRecords.isEmpty()) {
+            return consumerRecords;
         }
-        kafkaTelemetry.buildAndFinishSpan(recordsToTrace, consumer);
+        Map<TopicPartition, List<ConsumerRecord<K, V>>> recordsByPartition = new LinkedHashMap<>();
+        Set<ConsumerRecord<K, V>> tracedRecords = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (TopicPartition topicPartition : consumerRecords.partitions()) {
+            List<ConsumerRecord<K, V>> partitionRecords = consumerRecords.records(topicPartition);
+            recordsByPartition.put(topicPartition, partitionRecords);
+            for (ConsumerRecord<K, V> record : partitionRecords) {
+                if (!kafkaTelemetry.excludeTopic(record.topic()) && kafkaTelemetry.filterConsumerRecord(record, consumer)) {
+                    tracedRecords.add(record);
+                }
+            }
+        }
+        if (tracedRecords.isEmpty()) {
+            return consumerRecords;
+        }
+        return new TracingConsumerRecords(recordsByPartition, tracedRecords);
     }
 
     @Override
     public void commitSync() {
-        consumer.commitSync();
+        runWithInactiveContext(consumer::commitSync);
     }
 
     @Override
     public void commitSync(Duration duration) {
-        consumer.commitSync(duration);
+        runWithInactiveContext(() -> consumer.commitSync(duration));
     }
 
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> map) {
-        consumer.commitSync(map);
+        runWithInactiveContext(() -> consumer.commitSync(map));
     }
 
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> map, Duration duration) {
-        consumer.commitSync(map, duration);
+        runWithInactiveContext(() -> consumer.commitSync(map, duration));
     }
 
     @Override
     public void commitAsync() {
-        consumer.commitAsync();
+        runWithInactiveContext(consumer::commitAsync);
     }
 
     @Override
     public void commitAsync(OffsetCommitCallback offsetCommitCallback) {
-        consumer.commitAsync(offsetCommitCallback);
+        runWithInactiveContext(() -> consumer.commitAsync(offsetCommitCallback));
     }
 
     @Override
     public void commitAsync(Map<TopicPartition, OffsetAndMetadata> map, OffsetCommitCallback offsetCommitCallback) {
-        consumer.commitAsync(map, offsetCommitCallback);
+        runWithInactiveContext(() -> consumer.commitAsync(map, offsetCommitCallback));
     }
 
     @Override
     public void registerMetricForSubscription(KafkaMetric kafkaMetric) {
-        consumer.registerMetricForSubscription(kafkaMetric);
+        runWithInactiveContext(() -> consumer.registerMetricForSubscription(kafkaMetric));
     }
 
     @Override
     public void unregisterMetricFromSubscription(KafkaMetric kafkaMetric) {
-        consumer.unregisterMetricFromSubscription(kafkaMetric);
+        runWithInactiveContext(() -> consumer.unregisterMetricFromSubscription(kafkaMetric));
     }
 
     @Override
     public void seek(TopicPartition topicPartition, long l) {
-        consumer.seek(topicPartition, l);
+        runWithInactiveContext(() -> consumer.seek(topicPartition, l));
     }
 
     @Override
     public void seek(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
-        consumer.seek(topicPartition, offsetAndMetadata);
+        runWithInactiveContext(() -> consumer.seek(topicPartition, offsetAndMetadata));
     }
 
     @Override
     public void seekToBeginning(Collection<TopicPartition> collection) {
-        consumer.seekToBeginning(collection);
+        runWithInactiveContext(() -> consumer.seekToBeginning(collection));
     }
 
     @Override
     public void seekToEnd(Collection<TopicPartition> collection) {
-        consumer.seekToEnd(collection);
+        runWithInactiveContext(() -> consumer.seekToEnd(collection));
     }
 
     @Override
     public long position(TopicPartition topicPartition) {
-       return consumer.position(topicPartition);
+        return withInactiveContext(() -> consumer.position(topicPartition));
     }
 
     @Override
     public long position(TopicPartition topicPartition, Duration duration) {
-        return consumer.position(topicPartition, duration);
+        return withInactiveContext(() -> consumer.position(topicPartition, duration));
     }
 
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> set) {
-        return consumer.committed(set);
+        return withInactiveContext(() -> consumer.committed(set));
     }
 
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> set, Duration duration) {
-        return consumer.committed(set, duration);
+        return withInactiveContext(() -> consumer.committed(set, duration));
     }
 
     @Override
     public Uuid clientInstanceId(Duration duration) {
-        return consumer.clientInstanceId(duration);
+        return withInactiveContext(() -> consumer.clientInstanceId(duration));
     }
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        return consumer.metrics();
+        return withInactiveContext(consumer::metrics);
     }
 
     @Override
     public List<PartitionInfo> partitionsFor(String s) {
-        return consumer.partitionsFor(s);
+        return withInactiveContext(() -> consumer.partitionsFor(s));
     }
 
     @Override
     public List<PartitionInfo> partitionsFor(String s, Duration duration) {
-        return consumer.partitionsFor(s, duration);
+        return withInactiveContext(() -> consumer.partitionsFor(s, duration));
     }
 
     @Override
     public Map<String, List<PartitionInfo>> listTopics() {
-        return consumer.listTopics();
+        return withInactiveContext(consumer::listTopics);
     }
 
     @Override
     public Map<String, List<PartitionInfo>> listTopics(Duration duration) {
-        return consumer.listTopics(duration);
+        return withInactiveContext(() -> consumer.listTopics(duration));
     }
 
     @Override
     public Set<TopicPartition> paused() {
-        return consumer.paused();
+        return withInactiveContext(consumer::paused);
     }
 
     @Override
     public void pause(Collection<TopicPartition> collection) {
-        consumer.pause(collection);
+        runWithInactiveContext(() -> consumer.pause(collection));
     }
 
     @Override
     public void resume(Collection<TopicPartition> collection) {
-        consumer.resume(collection);
+        runWithInactiveContext(() -> consumer.resume(collection));
     }
 
     @Override
     public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> map) {
-        return consumer.offsetsForTimes(map);
+        return withInactiveContext(() -> consumer.offsetsForTimes(map));
     }
 
     @Override
     public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> map, Duration duration) {
-        return consumer.offsetsForTimes(map, duration);
+        return withInactiveContext(() -> consumer.offsetsForTimes(map, duration));
     }
 
     @Override
     public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> collection) {
-        return consumer.beginningOffsets(collection);
+        return withInactiveContext(() -> consumer.beginningOffsets(collection));
     }
 
     @Override
     public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> collection, Duration duration) {
-        return consumer.beginningOffsets(collection, duration);
+        return withInactiveContext(() -> consumer.beginningOffsets(collection, duration));
     }
 
     @Override
     public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> collection) {
-        return consumer.endOffsets(collection);
+        return withInactiveContext(() -> consumer.endOffsets(collection));
     }
 
     @Override
     public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> collection, Duration duration) {
-        return consumer.endOffsets(collection, duration);
+        return withInactiveContext(() -> consumer.endOffsets(collection, duration));
     }
 
     @Override
     public OptionalLong currentLag(TopicPartition topicPartition) {
-        return consumer.currentLag(topicPartition);
+        return withInactiveContext(() -> consumer.currentLag(topicPartition));
     }
 
     @Override
     public ConsumerGroupMetadata groupMetadata() {
-        return consumer.groupMetadata();
+        return withInactiveContext(consumer::groupMetadata);
     }
 
     @Override
     public void enforceRebalance() {
-        consumer.enforceRebalance();
+        runWithInactiveContext(consumer::enforceRebalance);
     }
 
     @Override
     public void enforceRebalance(String s) {
-        consumer.enforceRebalance(s);
+        runWithInactiveContext(() -> consumer.enforceRebalance(s));
     }
 
     @Override
     public void close() {
-        consumer.close();
+        runWithInactiveContext(consumer::close);
     }
 
     @Override
     public void close(Duration duration) {
-        consumer.close(CloseOptions.timeout(duration));
+        runWithInactiveContext(() -> consumer.close(CloseOptions.timeout(duration)));
     }
 
     @Override
     public void close(CloseOptions closeOptions) {
-        consumer.close(closeOptions);
+        runWithInactiveContext(() -> consumer.close(closeOptions));
     }
 
     @Override
     public void wakeup() {
-        consumer.wakeup();
+        runWithInactiveContext(consumer::wakeup);
+    }
+
+    private void activateRecordContext(ConsumerRecord<K, V> record) {
+        KafkaTelemetry.ConsumerRecordContext consumerRecordContext = kafkaTelemetry.startConsumerRecordSpan(record, consumer);
+        if (consumerRecordContext == null) {
+            return;
+        }
+        activeRecordContext = new ActiveRecordContext(consumerRecordContext, consumerRecordContext.context().makeCurrent());
+    }
+
+    private void closeActiveRecordContext() {
+        if (activeRecordContext == null) {
+            return;
+        }
+        ActiveRecordContext current = activeRecordContext;
+        activeRecordContext = null;
+        current.scope.close();
+        kafkaTelemetry.endConsumerRecordSpan(current.consumerRecordContext);
+    }
+
+    private <T> T withInactiveContext(Supplier<T> supplier) {
+        closeActiveRecordContext();
+        return supplier.get();
+    }
+
+    private void runWithInactiveContext(Runnable runnable) {
+        closeActiveRecordContext();
+        runnable.run();
+    }
+
+    private final class TracingConsumerRecords extends ConsumerRecords<K, V> {
+
+        private final Set<ConsumerRecord<K, V>> tracedRecords;
+
+        private TracingConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> recordsByPartition, Set<ConsumerRecord<K, V>> tracedRecords) {
+            super(recordsByPartition);
+            this.tracedRecords = tracedRecords;
+        }
+
+        @Override
+        public Iterator<ConsumerRecord<K, V>> iterator() {
+            Iterator<ConsumerRecord<K, V>> iterator = super.iterator();
+            return new Iterator<>() {
+                @Override
+                public boolean hasNext() {
+                    boolean hasNext = iterator.hasNext();
+                    if (!hasNext) {
+                        closeActiveRecordContext();
+                    }
+                    return hasNext;
+                }
+
+                @Override
+                public ConsumerRecord<K, V> next() {
+                    closeActiveRecordContext();
+                    ConsumerRecord<K, V> record = iterator.next();
+                    if (tracedRecords.contains(record)) {
+                        activateRecordContext(record);
+                    }
+                    return record;
+                }
+            };
+        }
+    }
+
+    private record ActiveRecordContext(KafkaTelemetry.ConsumerRecordContext consumerRecordContext, Scope scope) {
     }
 }

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,14 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.metrics.KafkaMetric;
 
 import java.time.Duration;
+import java.util.AbstractList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -381,7 +383,45 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
 
         @Override
         public Iterator<ConsumerRecord<K, V>> iterator() {
-            Iterator<ConsumerRecord<K, V>> iterator = super.iterator();
+            return instrumentedIterator(super.iterator());
+        }
+
+        @Override
+        public List<ConsumerRecord<K, V>> records(TopicPartition partition) {
+            return instrumentedRecords(super.records(partition));
+        }
+
+        @Override
+        public Iterable<ConsumerRecord<K, V>> records(String topic) {
+            return () -> instrumentedIterator(super.records(topic).iterator());
+        }
+
+        private List<ConsumerRecord<K, V>> instrumentedRecords(List<ConsumerRecord<K, V>> records) {
+            return new AbstractList<>() {
+                @Override
+                public ConsumerRecord<K, V> get(int index) {
+                    return records.get(index);
+                }
+
+                @Override
+                public int size() {
+                    return records.size();
+                }
+
+                @Override
+                public Iterator<ConsumerRecord<K, V>> iterator() {
+                    return instrumentedIterator(records.iterator());
+                }
+
+                @Override
+                public ListIterator<ConsumerRecord<K, V>> listIterator(int index) {
+                    return instrumentedListIterator(records.listIterator(index));
+                }
+            };
+        }
+
+        private Iterator<ConsumerRecord<K, V>> instrumentedIterator(Iterator<ConsumerRecord<K, V>> iterator) {
+            closeActiveRecordContext();
             return new Iterator<>() {
                 @Override
                 public boolean hasNext() {
@@ -400,6 +440,74 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
                         activateRecordContext(record);
                     }
                     return record;
+                }
+            };
+        }
+
+        private ListIterator<ConsumerRecord<K, V>> instrumentedListIterator(ListIterator<ConsumerRecord<K, V>> iterator) {
+            closeActiveRecordContext();
+            return new ListIterator<>() {
+                @Override
+                public boolean hasNext() {
+                    boolean hasNext = iterator.hasNext();
+                    if (!hasNext) {
+                        closeActiveRecordContext();
+                    }
+                    return hasNext;
+                }
+
+                @Override
+                public ConsumerRecord<K, V> next() {
+                    closeActiveRecordContext();
+                    ConsumerRecord<K, V> record = iterator.next();
+                    if (tracedRecords.contains(record)) {
+                        activateRecordContext(record);
+                    }
+                    return record;
+                }
+
+                @Override
+                public boolean hasPrevious() {
+                    boolean hasPrevious = iterator.hasPrevious();
+                    if (!hasPrevious) {
+                        closeActiveRecordContext();
+                    }
+                    return hasPrevious;
+                }
+
+                @Override
+                public ConsumerRecord<K, V> previous() {
+                    closeActiveRecordContext();
+                    ConsumerRecord<K, V> record = iterator.previous();
+                    if (tracedRecords.contains(record)) {
+                        activateRecordContext(record);
+                    }
+                    return record;
+                }
+
+                @Override
+                public int nextIndex() {
+                    return iterator.nextIndex();
+                }
+
+                @Override
+                public int previousIndex() {
+                    return iterator.previousIndex();
+                }
+
+                @Override
+                public void remove() {
+                    iterator.remove();
+                }
+
+                @Override
+                public void set(ConsumerRecord<K, V> record) {
+                    iterator.set(record);
+                }
+
+                @Override
+                public void add(ConsumerRecord<K, V> record) {
+                    iterator.add(record);
                 }
             };
         }

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
@@ -341,7 +341,7 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void wakeup() {
-        runWithInactiveContext(consumer::wakeup);
+        consumer.wakeup();
     }
 
     private void closeActiveRecordContext() {

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
@@ -393,7 +393,7 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
             return new AbstractList<>() {
                 @Override
                 public ConsumerRecord<K, V> get(int index) {
-                    return records.get(index);
+                    return activateNextRecord(records.get(index));
                 }
 
                 @Override

--- a/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
+++ b/tracing-opentelemetry-kafka/src/main/java/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumer.java
@@ -132,9 +132,9 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
         for (TopicPartition topicPartition : consumerRecords.partitions()) {
             List<ConsumerRecord<K, V>> partitionRecords = consumerRecords.records(topicPartition);
             recordsByPartition.put(topicPartition, partitionRecords);
-            for (ConsumerRecord<K, V> record : partitionRecords) {
-                if (!kafkaTelemetry.excludeTopic(record.topic()) && kafkaTelemetry.filterConsumerRecord(record, consumer)) {
-                    tracedRecords.add(record);
+            for (ConsumerRecord<K, V> consumerRecord : partitionRecords) {
+                if (!kafkaTelemetry.excludeTopic(consumerRecord.topic()) && kafkaTelemetry.filterConsumerRecord(consumerRecord, consumer)) {
+                    tracedRecords.add(consumerRecord);
                 }
             }
         }
@@ -344,14 +344,6 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
         runWithInactiveContext(consumer::wakeup);
     }
 
-    private void activateRecordContext(ConsumerRecord<K, V> record) {
-        KafkaTelemetry.ConsumerRecordContext consumerRecordContext = kafkaTelemetry.startConsumerRecordSpan(record, consumer);
-        if (consumerRecordContext == null) {
-            return;
-        }
-        activeRecordContext = new ActiveRecordContext(consumerRecordContext, consumerRecordContext.context().makeCurrent());
-    }
-
     private void closeActiveRecordContext() {
         if (activeRecordContext == null) {
             return;
@@ -376,6 +368,7 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
 
         private final Set<ConsumerRecord<K, V>> tracedRecords;
 
+        @SuppressWarnings("deprecation")
         private TracingConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> recordsByPartition, Set<ConsumerRecord<K, V>> tracedRecords) {
             super(recordsByPartition);
             this.tracedRecords = tracedRecords;
@@ -425,21 +418,12 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
             return new Iterator<>() {
                 @Override
                 public boolean hasNext() {
-                    boolean hasNext = iterator.hasNext();
-                    if (!hasNext) {
-                        closeActiveRecordContext();
-                    }
-                    return hasNext;
+                    return hasNextWithContext(iterator);
                 }
 
                 @Override
                 public ConsumerRecord<K, V> next() {
-                    closeActiveRecordContext();
-                    ConsumerRecord<K, V> record = iterator.next();
-                    if (tracedRecords.contains(record)) {
-                        activateRecordContext(record);
-                    }
-                    return record;
+                    return activateNextRecord(iterator.next());
                 }
             };
         }
@@ -449,21 +433,12 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
             return new ListIterator<>() {
                 @Override
                 public boolean hasNext() {
-                    boolean hasNext = iterator.hasNext();
-                    if (!hasNext) {
-                        closeActiveRecordContext();
-                    }
-                    return hasNext;
+                    return hasNextWithContext(iterator);
                 }
 
                 @Override
                 public ConsumerRecord<K, V> next() {
-                    closeActiveRecordContext();
-                    ConsumerRecord<K, V> record = iterator.next();
-                    if (tracedRecords.contains(record)) {
-                        activateRecordContext(record);
-                    }
-                    return record;
+                    return activateNextRecord(iterator.next());
                 }
 
                 @Override
@@ -477,12 +452,7 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
 
                 @Override
                 public ConsumerRecord<K, V> previous() {
-                    closeActiveRecordContext();
-                    ConsumerRecord<K, V> record = iterator.previous();
-                    if (tracedRecords.contains(record)) {
-                        activateRecordContext(record);
-                    }
-                    return record;
+                    return activateNextRecord(iterator.previous());
                 }
 
                 @Override
@@ -501,15 +471,34 @@ final class MicronautOtelKafkaConsumer<K, V> implements Consumer<K, V> {
                 }
 
                 @Override
-                public void set(ConsumerRecord<K, V> record) {
-                    iterator.set(record);
+                public void set(ConsumerRecord<K, V> consumerRecord) {
+                    iterator.set(consumerRecord);
                 }
 
                 @Override
-                public void add(ConsumerRecord<K, V> record) {
-                    iterator.add(record);
+                public void add(ConsumerRecord<K, V> consumerRecord) {
+                    iterator.add(consumerRecord);
                 }
             };
+        }
+
+        private ConsumerRecord<K, V> activateNextRecord(ConsumerRecord<K, V> consumerRecord) {
+            closeActiveRecordContext();
+            if (tracedRecords.contains(consumerRecord)) {
+                KafkaTelemetry.ConsumerRecordContext consumerRecordContext = kafkaTelemetry.startConsumerRecordSpan(consumerRecord, consumer);
+                if (consumerRecordContext != null) {
+                    activeRecordContext = new ActiveRecordContext(consumerRecordContext, consumerRecordContext.context().makeCurrent());
+                }
+            }
+            return consumerRecord;
+        }
+
+        private boolean hasNextWithContext(Iterator<ConsumerRecord<K, V>> iterator) {
+            boolean hasNext = iterator.hasNext();
+            if (!hasNext) {
+                closeActiveRecordContext();
+            }
+            return hasNext;
         }
     }
 

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryIntegrationSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryIntegrationSpec.groovy
@@ -4,22 +4,25 @@ import io.micronaut.configuration.kafka.annotation.KafkaClient
 import io.micronaut.configuration.kafka.annotation.KafkaListener
 import io.micronaut.configuration.kafka.annotation.OffsetReset
 import io.micronaut.configuration.kafka.annotation.Topic
-import io.micronaut.context.ApplicationContext
-import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
+import io.micronaut.tracing.annotation.NewSpan
 import io.micronaut.tracing.util.KafkaSetup
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import jakarta.inject.Inject
-import org.testcontainers.kafka.KafkaContainer
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
+
+import java.nio.charset.StandardCharsets
 
 @MicronautTest
 class KafkaTelemetryIntegrationSpec extends Specification implements TestPropertyProvider {
 
     @Inject TestKafkaClient testKafkaClient
     @Inject TestKafkaListener kafkaListener
+    @Inject TestTracingService testTracingService
     @Inject InMemorySpanExporter exporter
 
     @Override
@@ -31,13 +34,17 @@ class KafkaTelemetryIntegrationSpec extends Specification implements TestPropert
     void "test kafka stream application"() {
         given:
         PollingConditions conditions = new PollingConditions(timeout: 30)
+        String message = "Test message ${System.nanoTime()}"
 
         when:
-        testKafkaClient.publishText("Test message")
+        testTracingService.publishText(message)
 
         then:
         conditions.eventually {
-            kafkaListener.text.contains("Test message")
+            kafkaListener.text.contains(message)
+            kafkaListener.propagatedTraceId == testTracingService.traceId
+            kafkaListener.traceId == testTracingService.traceId
+            kafkaListener.traceparent
             exporter.finishedSpanItems.name.any { it.contains("publish") }
         }
     }
@@ -54,10 +61,28 @@ class KafkaTelemetryIntegrationSpec extends Specification implements TestPropert
     static class TestKafkaListener {
 
         private final List<String> text = new ArrayList<>()
+        String traceId
+        String traceparent
+        String propagatedTraceId
 
         @Topic("my-stream")
-        void updateAnalytics(String s) {
-            text.add(s)
+        void updateAnalytics(ConsumerRecord<?, String> record) {
+            text.add(record.value())
+            traceId = Span.current().spanContext.traceId
+            traceparent = record.headers().lastHeader("traceparent") != null ? new String(record.headers().lastHeader("traceparent").value(), StandardCharsets.UTF_8) : null
+            propagatedTraceId = traceparent?.split('-')?.length > 1 ? traceparent.split('-')[1] : null
+        }
+    }
+
+    static class TestTracingService {
+
+        @Inject TestKafkaClient testKafkaClient
+        String traceId
+
+        @NewSpan("publish")
+        void publishText(String message) {
+            traceId = Span.current().spanContext.traceId
+            testKafkaClient.publishText(message)
         }
     }
 

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryIntegrationSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/KafkaTelemetryIntegrationSpec.groovy
@@ -16,6 +16,8 @@ import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
 
 @MicronautTest
 class KafkaTelemetryIntegrationSpec extends Specification implements TestPropertyProvider {
@@ -42,9 +44,9 @@ class KafkaTelemetryIntegrationSpec extends Specification implements TestPropert
         then:
         conditions.eventually {
             kafkaListener.text.contains(message)
-            kafkaListener.propagatedTraceId == testTracingService.traceId
-            kafkaListener.traceId == testTracingService.traceId
-            kafkaListener.traceparent
+            kafkaListener.propagatedTraceId.get() == testTracingService.traceId
+            kafkaListener.traceId.get() == testTracingService.traceId
+            kafkaListener.traceparent.get()
             exporter.finishedSpanItems.name.any { it.contains("publish") }
         }
     }
@@ -60,17 +62,19 @@ class KafkaTelemetryIntegrationSpec extends Specification implements TestPropert
     @KafkaListener(offsetReset = OffsetReset.EARLIEST)
     static class TestKafkaListener {
 
-        private final List<String> text = new ArrayList<>()
-        String traceId
-        String traceparent
-        String propagatedTraceId
+        private final List<String> text = new CopyOnWriteArrayList<>()
+        private final AtomicReference<String> traceId = new AtomicReference<>()
+        private final AtomicReference<String> traceparent = new AtomicReference<>()
+        private final AtomicReference<String> propagatedTraceId = new AtomicReference<>()
 
         @Topic("my-stream")
         void updateAnalytics(ConsumerRecord<?, String> record) {
             text.add(record.value())
-            traceId = Span.current().spanContext.traceId
-            traceparent = record.headers().lastHeader("traceparent") != null ? new String(record.headers().lastHeader("traceparent").value(), StandardCharsets.UTF_8) : null
-            propagatedTraceId = traceparent?.split('-')?.length > 1 ? traceparent.split('-')[1] : null
+            traceId.set(Span.current().spanContext.traceId)
+            String traceparentHeader = record.headers().lastHeader("traceparent") != null ? new String(record.headers().lastHeader("traceparent").value(), StandardCharsets.UTF_8) : null
+            traceparent.set(traceparentHeader)
+            String[] traceparentParts = traceparentHeader?.split('-')
+            propagatedTraceId.set(traceparentParts?.length == 4 ? traceparentParts[1] : null)
         }
     }
 

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
@@ -566,6 +566,61 @@ class MicronautOtelKafkaConsumerSpec extends Specification {
         2 * processInstrumenter.end(_, _, null, null)
     }
 
+    void "wakeup from another thread does not close active record context"() {
+        given:
+        def processInstrumenter = Mock(Instrumenter)
+        def configuration = Mock(KafkaTelemetryConfiguration)
+        def kafkaTelemetry = new KafkaTelemetry(
+                Mock(OpenTelemetry),
+                Mock(Instrumenter),
+                processInstrumenter,
+                new ArrayList<KafkaTelemetryProducerTracingFilter>(),
+                new ArrayList<KafkaTelemetryConsumerTracingFilter>(),
+                configuration,
+                true
+        )
+        def micronautConsumer = new MicronautOtelKafkaConsumer(consumer, kafkaTelemetry)
+        def partition = new TopicPartition("topic", 0)
+        def record = new ConsumerRecord<String, String>("topic", 0, 0, "key", "value")
+        def records = new ConsumerRecords<String, String>([(partition): [record]])
+        ContextKey<String> contextKey = ContextKey.named("test-kafka-wakeup-context")
+
+        configuration.getIncludedTopics() >> Collections.emptyList()
+        configuration.getExcludedTopics() >> Collections.emptyList()
+        consumer.poll(Duration.ZERO) >> records
+        consumer.groupMetadata() >> new ConsumerGroupMetadata("group")
+        consumer.metrics() >> Collections.emptyMap()
+        processInstrumenter.shouldStart(_, _) >> true
+        processInstrumenter.start(_, _) >> Context.current().with(contextKey, "active")
+
+        when:
+        def tracedRecords = micronautConsumer.poll(Duration.ZERO)
+        def dispatchedRecord = tracedRecords.iterator().next()
+
+        then:
+        dispatchedRecord == record
+        Context.current().get(contextKey) == "active"
+
+        when:
+        def wakeupThread = Thread.start {
+            micronautConsumer.wakeup()
+        }
+        wakeupThread.join()
+
+        then:
+        Context.current().get(contextKey) == "active"
+        1 * consumer.wakeup()
+        0 * processInstrumenter.end(_, _, null, null)
+
+        when:
+        micronautConsumer.commitSync()
+
+        then:
+        Context.current().get(contextKey) == null
+        1 * processInstrumenter.end(_, _, null, null)
+        1 * consumer.commitSync()
+    }
+
     void "poll returns original records when no records should be traced"() {
         given:
         def configuration = Mock(KafkaTelemetryConfiguration)

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
@@ -509,6 +509,63 @@ class MicronautOtelKafkaConsumerSpec extends Specification {
         1 * consumer.commitSync()
     }
 
+    void "next record dispatch closes context left active by failed listener"() {
+        given:
+        def processInstrumenter = Mock(Instrumenter)
+        def configuration = Mock(KafkaTelemetryConfiguration)
+        def kafkaTelemetry = new KafkaTelemetry(
+                Mock(OpenTelemetry),
+                Mock(Instrumenter),
+                processInstrumenter,
+                new ArrayList<KafkaTelemetryProducerTracingFilter>(),
+                new ArrayList<KafkaTelemetryConsumerTracingFilter>(),
+                configuration,
+                true
+        )
+        def micronautConsumer = new MicronautOtelKafkaConsumer(consumer, kafkaTelemetry)
+        def partition = new TopicPartition("topic", 0)
+        def firstRecord = new ConsumerRecord<String, String>("topic", 0, 0, "key", "first")
+        def secondRecord = new ConsumerRecord<String, String>("topic", 0, 1, "key", "second")
+        def records = new ConsumerRecords<String, String>([(partition): [firstRecord, secondRecord]])
+        ContextKey<String> contextKey = ContextKey.named("test-kafka-listener-failure-context")
+        def observedContexts = []
+
+        configuration.getIncludedTopics() >> Collections.emptyList()
+        configuration.getExcludedTopics() >> Collections.emptyList()
+        consumer.poll(Duration.ZERO) >> records
+        consumer.groupMetadata() >> new ConsumerGroupMetadata("group")
+        consumer.metrics() >> Collections.emptyMap()
+        processInstrumenter.shouldStart(_, _) >> true
+        processInstrumenter.start(_, _) >>> [
+                Context.current().with(contextKey, "first"),
+                Context.current().with(contextKey, "second")
+        ]
+
+        when:
+        def tracedRecords = micronautConsumer.poll(Duration.ZERO)
+        def iterator = tracedRecords.iterator()
+        ConsumerRecord<String, String> firstDispatched
+        ConsumerRecord<String, String> secondDispatched
+        try {
+            firstDispatched = iterator.next()
+            observedContexts << Context.current().get(contextKey)
+            throw new IllegalStateException("listener failure")
+        } catch (IllegalStateException ignored) {
+            // Continue dispatching the next record, as a listener container can after a handled failure.
+        }
+        secondDispatched = iterator.next()
+        observedContexts << Context.current().get(contextKey)
+        boolean exhausted = !iterator.hasNext()
+
+        then:
+        firstDispatched == firstRecord
+        secondDispatched == secondRecord
+        observedContexts == ["first", "second"]
+        exhausted
+        Context.current().get(contextKey) == null
+        2 * processInstrumenter.end(_, _, null, null)
+    }
+
     void "poll returns original records when no records should be traced"() {
         given:
         def configuration = Mock(KafkaTelemetryConfiguration)

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
@@ -1,12 +1,20 @@
 package io.micronaut.tracing.opentelemetry.instrument.kafka
 
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import org.apache.kafka.clients.consumer.CloseOptions
 import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.SubscriptionPattern
-import java.time.Duration
+import org.apache.kafka.common.TopicPartition
 import spock.lang.Specification
+
+import java.time.Duration
 
 class MicronautOtelKafkaConsumerSpec extends Specification {
 
@@ -321,6 +329,74 @@ class MicronautOtelKafkaConsumerSpec extends Specification {
 
         then:
         1 * consumer.unsubscribe()
+    }
+
+    void "traced records activate context from partition and topic iterators and close stale context"() {
+        given:
+        def processInstrumenter = Mock(Instrumenter)
+        def configuration = Mock(KafkaTelemetryConfiguration)
+        def kafkaTelemetry = new KafkaTelemetry(
+                Mock(OpenTelemetry),
+                Mock(Instrumenter),
+                processInstrumenter,
+                new ArrayList<KafkaTelemetryProducerTracingFilter>(),
+                new ArrayList<KafkaTelemetryConsumerTracingFilter>(),
+                configuration,
+                true
+        )
+        def micronautConsumer = new MicronautOtelKafkaConsumer(consumer, kafkaTelemetry)
+        def partition = new TopicPartition("topic", 0)
+        def firstRecord = new ConsumerRecord<String, String>("topic", 0, 0, "key", "first")
+        def secondRecord = new ConsumerRecord<String, String>("topic", 0, 1, "key", "second")
+        def records = new ConsumerRecords<String, String>([(partition): [firstRecord, secondRecord]])
+        ContextKey<String> contextKey = ContextKey.named("test-kafka-context")
+
+        configuration.getIncludedTopics() >> Collections.emptyList()
+        configuration.getExcludedTopics() >> Collections.emptyList()
+        consumer.poll(Duration.ZERO) >> records
+        consumer.groupMetadata() >> new ConsumerGroupMetadata("group")
+        consumer.metrics() >> Collections.emptyMap()
+        processInstrumenter.shouldStart(_, _) >> true
+        processInstrumenter.start(_, _) >> Context.current().with(contextKey, "active")
+
+        when:
+        def tracedRecords = micronautConsumer.poll(Duration.ZERO)
+        def partitionIterator = tracedRecords.records(partition).iterator()
+        def partitionRecord = partitionIterator.next()
+
+        then:
+        partitionRecord == firstRecord
+        Context.current().get(contextKey) == "active"
+
+        when:
+        tracedRecords.iterator()
+
+        then:
+        Context.current().get(contextKey) == null
+        1 * processInstrumenter.end(_, _, null, null)
+
+        when:
+        def topicIterator = tracedRecords.records("topic").iterator()
+        def topicRecord = topicIterator.next()
+
+        then:
+        topicRecord == firstRecord
+        Context.current().get(contextKey) == "active"
+
+        when:
+        topicIterator.next()
+
+        then:
+        Context.current().get(contextKey) == "active"
+        1 * processInstrumenter.end(_, _, null, null)
+
+        when:
+        boolean hasNext = topicIterator.hasNext()
+
+        then:
+        !hasNext
+        Context.current().get(contextKey) == null
+        1 * processInstrumenter.end(_, _, null, null)
     }
 
 }

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
@@ -456,6 +456,59 @@ class MicronautOtelKafkaConsumerSpec extends Specification {
         thrown(UnsupportedOperationException)
     }
 
+    void "traced records activate context from partition indexed access"() {
+        given:
+        def processInstrumenter = Mock(Instrumenter)
+        def configuration = Mock(KafkaTelemetryConfiguration)
+        def kafkaTelemetry = new KafkaTelemetry(
+                Mock(OpenTelemetry),
+                Mock(Instrumenter),
+                processInstrumenter,
+                new ArrayList<KafkaTelemetryProducerTracingFilter>(),
+                new ArrayList<KafkaTelemetryConsumerTracingFilter>(),
+                configuration,
+                true
+        )
+        def micronautConsumer = new MicronautOtelKafkaConsumer(consumer, kafkaTelemetry)
+        def partition = new TopicPartition("topic", 0)
+        def firstRecord = new ConsumerRecord<String, String>("topic", 0, 0, "key", "first")
+        def secondRecord = new ConsumerRecord<String, String>("topic", 0, 1, "key", "second")
+        def records = new ConsumerRecords<String, String>([(partition): [firstRecord, secondRecord]])
+        ContextKey<String> contextKey = ContextKey.named("test-kafka-index-context")
+
+        configuration.getIncludedTopics() >> Collections.emptyList()
+        configuration.getExcludedTopics() >> Collections.emptyList()
+        consumer.poll(Duration.ZERO) >> records
+        consumer.groupMetadata() >> new ConsumerGroupMetadata("group")
+        consumer.metrics() >> Collections.emptyMap()
+        processInstrumenter.shouldStart(_, _) >> true
+        processInstrumenter.start(_, _) >> Context.current().with(contextKey, "active")
+
+        when:
+        def tracedRecords = micronautConsumer.poll(Duration.ZERO)
+        def firstIndexedRecord = tracedRecords.records(partition).get(0)
+
+        then:
+        firstIndexedRecord == firstRecord
+        Context.current().get(contextKey) == "active"
+
+        when:
+        def secondIndexedRecord = tracedRecords.records(partition).get(1)
+
+        then:
+        secondIndexedRecord == secondRecord
+        Context.current().get(contextKey) == "active"
+        1 * processInstrumenter.end(_, _, null, null)
+
+        when:
+        micronautConsumer.commitSync()
+
+        then:
+        Context.current().get(contextKey) == null
+        1 * processInstrumenter.end(_, _, null, null)
+        1 * consumer.commitSync()
+    }
+
     void "poll returns original records when no records should be traced"() {
         given:
         def configuration = Mock(KafkaTelemetryConfiguration)

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/opentelemetry/instrument/kafka/MicronautOtelKafkaConsumerSpec.groovy
@@ -109,7 +109,7 @@ class MicronautOtelKafkaConsumerSpec extends Specification {
         1 * consumer.commitSync()
 
         when:
-        micronautConsumer.commitSync(null)
+        micronautConsumer.commitSync((Duration) null)
 
         then:
         1 * consumer.commitSync(null)
@@ -271,6 +271,12 @@ class MicronautOtelKafkaConsumerSpec extends Specification {
         1 * consumer.groupMetadata()
 
         when:
+        micronautConsumer.clientInstanceId(null)
+
+        then:
+        1 * consumer.clientInstanceId(null)
+
+        when:
         micronautConsumer.enforceRebalance()
 
         then:
@@ -397,6 +403,81 @@ class MicronautOtelKafkaConsumerSpec extends Specification {
         !hasNext
         Context.current().get(contextKey) == null
         1 * processInstrumenter.end(_, _, null, null)
+
+        when:
+        def listIterator = tracedRecords.records(partition).listIterator()
+        def listRecord = listIterator.next()
+
+        then:
+        listRecord == firstRecord
+        Context.current().get(contextKey) == "active"
+
+        when:
+        int nextIndex = listIterator.nextIndex()
+        int previousIndex = listIterator.previousIndex()
+
+        then:
+        nextIndex == 1
+        previousIndex == 0
+        Context.current().get(contextKey) == "active"
+
+        when:
+        def previousRecord = listIterator.previous()
+
+        then:
+        previousRecord == firstRecord
+        Context.current().get(contextKey) == "active"
+        1 * processInstrumenter.end(_, _, null, null)
+
+        when:
+        boolean hasPrevious = listIterator.hasPrevious()
+
+        then:
+        !hasPrevious
+        Context.current().get(contextKey) == null
+        1 * processInstrumenter.end(_, _, null, null)
+
+        when:
+        tracedRecords.records(partition).listIterator().remove()
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        tracedRecords.records(partition).listIterator().set(firstRecord)
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        tracedRecords.records(partition).listIterator().add(firstRecord)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    void "poll returns original records when no records should be traced"() {
+        given:
+        def configuration = Mock(KafkaTelemetryConfiguration)
+        def kafkaTelemetry = new KafkaTelemetry(
+                Mock(OpenTelemetry),
+                Mock(Instrumenter),
+                Mock(Instrumenter),
+                new ArrayList<KafkaTelemetryProducerTracingFilter>(),
+                new ArrayList<KafkaTelemetryConsumerTracingFilter>(),
+                configuration,
+                true
+        )
+        def micronautConsumer = new MicronautOtelKafkaConsumer(consumer, kafkaTelemetry)
+        def partition = new TopicPartition("topic", 0)
+        def records = new ConsumerRecords<String, String>([(partition): [new ConsumerRecord<String, String>("topic", 0, 0, "key", "value")]])
+
+        configuration.getIncludedTopics() >> Collections.emptyList()
+        configuration.getExcludedTopics() >> ["topic"]
+        consumer.poll(Duration.ZERO) >> records
+
+        expect:
+        micronautConsumer.poll(Duration.ZERO).is(records)
     }
 
 }

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry-kafka/src/test/groovy/io/micronaut/tracing/util/TestDefaultOpenTelemetryFactory.java
@@ -21,6 +21,8 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.tracing.opentelemetry.DefaultOpenTelemetryFactory;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
@@ -45,7 +47,9 @@ public class TestDefaultOpenTelemetryFactory {
             .setTracerProvider(SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(inMemorySpanExporter))
                 .build()
-            ).build();
+            )
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+            .build();
     }
 
     @Singleton


### PR DESCRIPTION
## Summary
- activate Kafka consumer process spans while consumed records are iterated
- close active record spans before delegating other consumer operations or starting new iterators
- instrument partition/topic record accessors and add unit coverage for those iteration paths
- make integration-test listener state thread-safe and parse W3C traceparent consistently

## Tests
- ./gradlew :micronaut-tracing-opentelemetry-kafka:test --tests '*MicronautOtelKafkaConsumerSpec'
- ./gradlew :micronaut-tracing-opentelemetry-kafka:test --tests '*KafkaTelemetryIntegrationSpec'
- ./gradlew :micronaut-tracing-opentelemetry-kafka:spotlessCheck
- git diff --check

Resolves #819
