### PR TITLE
Fix OpenTelemetry SQS propagation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,7 +102,9 @@ opentelemetry-instrumentation-jdbc = { module = 'io.opentelemetry.instrumentatio
 opentelemetry-instrumentation-r2dbc = { module = 'io.opentelemetry.instrumentation:opentelemetry-r2dbc-1.0' }
 opentelemetry-aws-sdk = { module = 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2' }
 testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka"}
+awssdk-bedrockruntime = { module = 'software.amazon.awssdk:bedrockruntime' }
 awssdk-core = { module = 'software.amazon.awssdk:sdk-core' }
+awssdk-sqs = { module = 'software.amazon.awssdk:sqs' }
 
 # BOMs
 boms-opentelemetry = { module = 'io.opentelemetry:opentelemetry-bom', version.ref = 'managed-opentelemetry' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,7 +102,6 @@ opentelemetry-instrumentation-jdbc = { module = 'io.opentelemetry.instrumentatio
 opentelemetry-instrumentation-r2dbc = { module = 'io.opentelemetry.instrumentation:opentelemetry-r2dbc-1.0' }
 opentelemetry-aws-sdk = { module = 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2' }
 testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka"}
-awssdk-bedrockruntime = { module = 'software.amazon.awssdk:bedrockruntime' }
 awssdk-core = { module = 'software.amazon.awssdk:sdk-core' }
 awssdk-sqs = { module = 'software.amazon.awssdk:sqs' }
 

--- a/src/main/docs/guide/opentelemetry/awsSdkInstrumentation.adoc
+++ b/src/main/docs/guide/opentelemetry/awsSdkInstrumentation.adoc
@@ -8,3 +8,22 @@ dependency:micronaut-aws-sdk-v2[groupId=io.micronaut.aws,scope=compile]
 
 `micronaut-aws-sdk-v2` dependency creates a bean of type `SdkClientBuilder`. To instrument the AWS SDK, Micronaut OpenTelemetry registers a tracing interceptor
 via a bean creation listener for the bean of type `SdkClientBuilder`.
+
+For SQS, Micronaut OpenTelemetry also wraps `SqsClient` and `SqsAsyncClient` beans so OpenTelemetry can propagate messaging context through SQS message attributes.
+
+To propagate the configured OpenTelemetry context through SQS messages, enable the AWS SDK messaging propagator:
+
+[configuration]
+----
+otel:
+  propagators: tracecontext,baggage
+  instrumentation:
+    aws-sdk:
+      experimental-use-propagator-for-messaging: true
+    messaging:
+      experimental:
+        receive-telemetry:
+          enabled: true
+----
+
+You can also enable `otel.instrumentation.aws-sdk.experimental-span-attributes` to capture experimental AWS SDK span attributes.

--- a/src/main/docs/guide/opentelemetry/awsSdkInstrumentation.adoc
+++ b/src/main/docs/guide/opentelemetry/awsSdkInstrumentation.adoc
@@ -9,9 +9,9 @@ dependency:micronaut-aws-sdk-v2[groupId=io.micronaut.aws,scope=compile]
 `micronaut-aws-sdk-v2` dependency creates a bean of type `SdkClientBuilder`. To instrument the AWS SDK, Micronaut OpenTelemetry registers a tracing interceptor
 via a bean creation listener for the bean of type `SdkClientBuilder`.
 
-For SQS, Micronaut OpenTelemetry also wraps `SqsClient` and `SqsAsyncClient` beans so OpenTelemetry can propagate messaging context through SQS message attributes.
+For SQS, Micronaut OpenTelemetry also wraps `SqsClient` and `SqsAsyncClient` beans when messaging propagation or receive telemetry is enabled.
 
-To propagate the configured OpenTelemetry context through SQS messages, enable the AWS SDK messaging propagator:
+To propagate the configured OpenTelemetry context through sent SQS messages, enable the AWS SDK messaging propagator:
 
 [configuration]
 ----
@@ -20,6 +20,14 @@ otel:
   instrumentation:
     aws-sdk:
       experimental-use-propagator-for-messaging: true
+----
+
+Enable messaging receive telemetry separately when you want consumer-side receive telemetry for SQS messages:
+
+[configuration]
+----
+otel:
+  instrumentation:
     messaging:
       experimental:
         receive-telemetry:

--- a/tracing-opentelemetry/build.gradle
+++ b/tracing-opentelemetry/build.gradle
@@ -25,8 +25,11 @@ dependencies {
     implementation(platform(libs.micronaut.aws))
     compileOnly(libs.opentelemetry.aws.sdk)
     compileOnly(libs.awssdk.core)
+    compileOnly(libs.awssdk.sqs)
     testImplementation(libs.opentelemetry.aws.sdk)
+    testImplementation(libs.awssdk.bedrockruntime)
     testImplementation(libs.awssdk.core)
+    testImplementation(libs.awssdk.sqs)
 
     compileOnly mn.kotlinx.coroutines.core
     compileOnly mn.kotlinx.coroutines.reactor

--- a/tracing-opentelemetry/build.gradle
+++ b/tracing-opentelemetry/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     compileOnly(libs.awssdk.core)
     compileOnly(libs.awssdk.sqs)
     testImplementation(libs.opentelemetry.aws.sdk)
-    testImplementation(libs.awssdk.bedrockruntime)
     testImplementation(libs.awssdk.core)
     testImplementation(libs.awssdk.sqs)
 

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryConfiguration.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.xray;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Configuration for OpenTelemetry AWS SDK instrumentation.
+ *
+ * @author Nemanja Mikic
+ * @since 8.0.0
+ */
+@Internal
+@ConfigurationProperties(AwsSdkTelemetryConfiguration.PREFIX)
+public class AwsSdkTelemetryConfiguration {
+    public static final String PREFIX = "otel.instrumentation.aws-sdk";
+
+    private boolean experimentalSpanAttributes;
+    private boolean experimentalUsePropagatorForMessaging;
+
+    /**
+     * @return Whether experimental AWS SDK span attributes should be captured.
+     */
+    public boolean isExperimentalSpanAttributes() {
+        return experimentalSpanAttributes;
+    }
+
+    /**
+     * @param experimentalSpanAttributes Whether experimental AWS SDK span attributes should be captured.
+     */
+    public void setExperimentalSpanAttributes(boolean experimentalSpanAttributes) {
+        this.experimentalSpanAttributes = experimentalSpanAttributes;
+    }
+
+    /**
+     * @return Whether messaging propagation should use the configured OpenTelemetry propagator.
+     */
+    public boolean isExperimentalUsePropagatorForMessaging() {
+        return experimentalUsePropagatorForMessaging;
+    }
+
+    /**
+     * @param experimentalUsePropagatorForMessaging Whether messaging propagation should use the configured OpenTelemetry propagator.
+     */
+    public void setExperimentalUsePropagatorForMessaging(boolean experimentalUsePropagatorForMessaging) {
+        this.experimentalUsePropagatorForMessaging = experimentalUsePropagatorForMessaging;
+    }
+}

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.xray;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
+import jakarta.inject.Singleton;
+import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
+
+/**
+ * Creates the OpenTelemetry AWS SDK instrumentation.
+ *
+ * @author Nemanja Mikic
+ * @since 8.0.0
+ */
+@Internal
+@Factory
+@Requires(classes = {AwsSdkTelemetry.class, SdkClientBuilder.class})
+public class AwsSdkTelemetryFactory {
+
+    /**
+     * @param openTelemetry OpenTelemetry
+     * @param awsSdkTelemetryConfiguration AWS SDK instrumentation configuration
+     * @param messagingTelemetryConfiguration messaging instrumentation configuration
+     * @return the AWS SDK telemetry instrumentation
+     */
+    @Singleton
+    AwsSdkTelemetry awsSdkTelemetry(OpenTelemetry openTelemetry,
+                                    AwsSdkTelemetryConfiguration awsSdkTelemetryConfiguration,
+                                    MessagingTelemetryConfiguration messagingTelemetryConfiguration) {
+        return AwsSdkTelemetry.builder(openTelemetry)
+            .setCaptureExperimentalSpanAttributes(awsSdkTelemetryConfiguration.isExperimentalSpanAttributes())
+            .setUseConfiguredPropagatorForMessaging(awsSdkTelemetryConfiguration.isExperimentalUsePropagatorForMessaging())
+            .setMessagingReceiveInstrumentationEnabled(messagingTelemetryConfiguration.isEnabled())
+            .build();
+    }
+}

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryFactory.java
@@ -41,13 +41,13 @@ public class AwsSdkTelemetryFactory {
      * @return the AWS SDK telemetry instrumentation
      */
     @Singleton
-    AwsSdkTelemetry awsSdkTelemetry(OpenTelemetry openTelemetry,
-                                    AwsSdkTelemetryConfiguration awsSdkTelemetryConfiguration,
-                                    MessagingTelemetryConfiguration messagingTelemetryConfiguration) {
-        return AwsSdkTelemetry.builder(openTelemetry)
+    AwsSdkTelemetryProvider awsSdkTelemetryProvider(OpenTelemetry openTelemetry,
+                                                    AwsSdkTelemetryConfiguration awsSdkTelemetryConfiguration,
+                                                    MessagingTelemetryConfiguration messagingTelemetryConfiguration) {
+        return new AwsSdkTelemetryProvider(AwsSdkTelemetry.builder(openTelemetry)
             .setCaptureExperimentalSpanAttributes(awsSdkTelemetryConfiguration.isExperimentalSpanAttributes())
             .setUseConfiguredPropagatorForMessaging(awsSdkTelemetryConfiguration.isExperimentalUsePropagatorForMessaging())
-            .setMessagingReceiveInstrumentationEnabled(messagingTelemetryConfiguration.isEnabled())
-            .build();
+            .setMessagingReceiveTelemetryEnabled(messagingTelemetryConfiguration.isEnabled())
+            .build());
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryProvider.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.xray;
+
+import io.micronaut.core.annotation.Internal;
+import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+/**
+ * Provides AWS SDK telemetry operations without exposing the OpenTelemetry AWS SDK implementation as a bean.
+ *
+ * @author Nemanja Mikic
+ * @since 8.0.0
+ */
+@Internal
+final class AwsSdkTelemetryProvider {
+    private final AwsSdkTelemetry awsSdkTelemetry;
+
+    AwsSdkTelemetryProvider(AwsSdkTelemetry awsSdkTelemetry) {
+        this.awsSdkTelemetry = awsSdkTelemetry;
+    }
+
+    ExecutionInterceptor newExecutionInterceptor() {
+        return awsSdkTelemetry.createExecutionInterceptor();
+    }
+
+    SqsClient wrap(SqsClient sqsClient) {
+        return awsSdkTelemetry.wrap(sqsClient);
+    }
+
+    SqsAsyncClient wrap(SqsAsyncClient sqsAsyncClient) {
+        return awsSdkTelemetry.wrap(sqsAsyncClient);
+    }
+}

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryProvider.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryProvider.java
@@ -18,8 +18,8 @@ package io.micronaut.tracing.opentelemetry.xray;
 import io.micronaut.core.annotation.Internal;
 import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.SqsClient;
+
+import java.util.function.Function;
 
 /**
  * Provides AWS SDK telemetry operations without exposing the OpenTelemetry AWS SDK implementation as a bean.
@@ -39,11 +39,7 @@ final class AwsSdkTelemetryProvider {
         return awsSdkTelemetry.createExecutionInterceptor();
     }
 
-    SqsClient wrap(SqsClient sqsClient) {
-        return awsSdkTelemetry.wrap(sqsClient);
-    }
-
-    SqsAsyncClient wrap(SqsAsyncClient sqsAsyncClient) {
-        return awsSdkTelemetry.wrap(sqsAsyncClient);
+    <T> T withTelemetry(Function<AwsSdkTelemetry, T> function) {
+        return function.apply(awsSdkTelemetry);
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/MessagingTelemetryConfiguration.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/MessagingTelemetryConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.opentelemetry.xray;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Configuration for OpenTelemetry messaging instrumentation.
+ *
+ * @author Nemanja Mikic
+ * @since 8.0.0
+ */
+@Internal
+@ConfigurationProperties(MessagingTelemetryConfiguration.PREFIX)
+public class MessagingTelemetryConfiguration {
+    public static final String PREFIX = "otel.instrumentation.messaging.experimental.receive-telemetry";
+
+    private boolean enabled;
+
+    /**
+     * @return Whether messaging receive telemetry is enabled.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * @param enabled Whether messaging receive telemetry is enabled.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SdkClientBuilderListener.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SdkClientBuilderListener.java
@@ -38,14 +38,14 @@ import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 public class SdkClientBuilderListener implements BeanCreatedEventListener<SdkClientBuilder<?, ?>> {
     private static final Logger LOG = LoggerFactory.getLogger(SdkClientBuilderListener.class);
 
-    private final AwsSdkTelemetry awsSdkTelemetry;
+    private final AwsSdkTelemetryProvider awsSdkTelemetryProvider;
 
     /**
      *
-     * @param awsSdkTelemetry AWS SDK telemetry
+     * @param awsSdkTelemetryProvider AWS SDK telemetry provider
      */
-    public SdkClientBuilderListener(AwsSdkTelemetry awsSdkTelemetry) {
-        this.awsSdkTelemetry = awsSdkTelemetry;
+    public SdkClientBuilderListener(AwsSdkTelemetryProvider awsSdkTelemetryProvider) {
+        this.awsSdkTelemetryProvider = awsSdkTelemetryProvider;
     }
 
     /**
@@ -60,6 +60,6 @@ public class SdkClientBuilderListener implements BeanCreatedEventListener<SdkCli
             LOG.trace("Registering OpenTelemetry tracing interceptor to {}", event.getBean().getClass().getSimpleName());
         }
         return event.getBean().overrideConfiguration(builder ->
-            builder.addExecutionInterceptor(awsSdkTelemetry.newExecutionInterceptor()));
+            builder.addExecutionInterceptor(awsSdkTelemetryProvider.newExecutionInterceptor()));
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsAsyncClientBeanCreatedEventListener.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsAsyncClientBeanCreatedEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,43 +23,34 @@ import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 /**
- * Configures a Tracing Interceptor for all sdk client builders.
- * @see <a href="https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr">Instrumenting the AWS SDK</a>
+ * Wraps asynchronous SQS clients for OpenTelemetry message propagation.
  *
- * @author Sergio del Amo
- * @since 4.2.0
+ * @author Nemanja Mikic
+ * @since 8.0.0
  */
 @Internal
-@Requires(classes = {AwsSdkTelemetry.class, SdkClientBuilder.class})
+@Requires(classes = {AwsSdkTelemetry.class, SqsAsyncClient.class})
 @Singleton
-public class SdkClientBuilderListener implements BeanCreatedEventListener<SdkClientBuilder<?, ?>> {
-    private static final Logger LOG = LoggerFactory.getLogger(SdkClientBuilderListener.class);
+public class SqsAsyncClientBeanCreatedEventListener implements BeanCreatedEventListener<SqsAsyncClient> {
+    private static final Logger LOG = LoggerFactory.getLogger(SqsAsyncClientBeanCreatedEventListener.class);
 
     private final AwsSdkTelemetry awsSdkTelemetry;
 
     /**
-     *
      * @param awsSdkTelemetry AWS SDK telemetry
      */
-    public SdkClientBuilderListener(AwsSdkTelemetry awsSdkTelemetry) {
+    public SqsAsyncClientBeanCreatedEventListener(AwsSdkTelemetry awsSdkTelemetry) {
         this.awsSdkTelemetry = awsSdkTelemetry;
     }
 
-    /**
-     * Add an OpenTelemetry execution interceptor to {@link SdkClientBuilder}.
-     *
-     * @param event bean created event
-     * @return sdk client builder
-     */
     @Override
-    public SdkClientBuilder<?, ?> onCreated(BeanCreatedEvent<SdkClientBuilder<?, ?>> event) {
+    public SqsAsyncClient onCreated(BeanCreatedEvent<SqsAsyncClient> event) {
         if (LOG.isTraceEnabled()) {
-            LOG.trace("Registering OpenTelemetry tracing interceptor to {}", event.getBean().getClass().getSimpleName());
+            LOG.trace("Wrapping OpenTelemetry asynchronous SQS client {}", event.getBean().getClass().getSimpleName());
         }
-        return event.getBean().overrideConfiguration(builder ->
-            builder.addExecutionInterceptor(awsSdkTelemetry.newExecutionInterceptor()));
+        return awsSdkTelemetry.wrap(event.getBean());
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsAsyncClientBeanCreatedEventListener.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsAsyncClientBeanCreatedEventListener.java
@@ -62,7 +62,7 @@ public class SqsAsyncClientBeanCreatedEventListener implements BeanCreatedEventL
         if (LOG.isTraceEnabled()) {
             LOG.trace("Wrapping OpenTelemetry asynchronous SQS client {}", event.getBean().getClass().getSimpleName());
         }
-        return awsSdkTelemetryProvider.wrap(event.getBean());
+        return awsSdkTelemetryProvider.withTelemetry(awsSdkTelemetry -> awsSdkTelemetry.wrap(event.getBean()));
     }
 
     private boolean shouldWrap() {

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsAsyncClientBeanCreatedEventListener.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsAsyncClientBeanCreatedEventListener.java
@@ -37,20 +37,35 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 public class SqsAsyncClientBeanCreatedEventListener implements BeanCreatedEventListener<SqsAsyncClient> {
     private static final Logger LOG = LoggerFactory.getLogger(SqsAsyncClientBeanCreatedEventListener.class);
 
-    private final AwsSdkTelemetry awsSdkTelemetry;
+    private final AwsSdkTelemetryProvider awsSdkTelemetryProvider;
+    private final AwsSdkTelemetryConfiguration awsSdkTelemetryConfiguration;
+    private final MessagingTelemetryConfiguration messagingTelemetryConfiguration;
 
     /**
-     * @param awsSdkTelemetry AWS SDK telemetry
+     * @param awsSdkTelemetryProvider AWS SDK telemetry provider
+     * @param awsSdkTelemetryConfiguration AWS SDK instrumentation configuration
+     * @param messagingTelemetryConfiguration messaging instrumentation configuration
      */
-    public SqsAsyncClientBeanCreatedEventListener(AwsSdkTelemetry awsSdkTelemetry) {
-        this.awsSdkTelemetry = awsSdkTelemetry;
+    public SqsAsyncClientBeanCreatedEventListener(AwsSdkTelemetryProvider awsSdkTelemetryProvider,
+                                                  AwsSdkTelemetryConfiguration awsSdkTelemetryConfiguration,
+                                                  MessagingTelemetryConfiguration messagingTelemetryConfiguration) {
+        this.awsSdkTelemetryProvider = awsSdkTelemetryProvider;
+        this.awsSdkTelemetryConfiguration = awsSdkTelemetryConfiguration;
+        this.messagingTelemetryConfiguration = messagingTelemetryConfiguration;
     }
 
     @Override
     public SqsAsyncClient onCreated(BeanCreatedEvent<SqsAsyncClient> event) {
+        if (!shouldWrap()) {
+            return event.getBean();
+        }
         if (LOG.isTraceEnabled()) {
             LOG.trace("Wrapping OpenTelemetry asynchronous SQS client {}", event.getBean().getClass().getSimpleName());
         }
-        return awsSdkTelemetry.wrap(event.getBean());
+        return awsSdkTelemetryProvider.wrap(event.getBean());
+    }
+
+    private boolean shouldWrap() {
+        return awsSdkTelemetryConfiguration.isExperimentalUsePropagatorForMessaging() || messagingTelemetryConfiguration.isEnabled();
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsClientBeanCreatedEventListener.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsClientBeanCreatedEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,43 +23,34 @@ import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 /**
- * Configures a Tracing Interceptor for all sdk client builders.
- * @see <a href="https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr">Instrumenting the AWS SDK</a>
+ * Wraps SQS clients for OpenTelemetry message propagation.
  *
- * @author Sergio del Amo
- * @since 4.2.0
+ * @author Nemanja Mikic
+ * @since 8.0.0
  */
 @Internal
-@Requires(classes = {AwsSdkTelemetry.class, SdkClientBuilder.class})
+@Requires(classes = {AwsSdkTelemetry.class, SqsClient.class})
 @Singleton
-public class SdkClientBuilderListener implements BeanCreatedEventListener<SdkClientBuilder<?, ?>> {
-    private static final Logger LOG = LoggerFactory.getLogger(SdkClientBuilderListener.class);
+public class SqsClientBeanCreatedEventListener implements BeanCreatedEventListener<SqsClient> {
+    private static final Logger LOG = LoggerFactory.getLogger(SqsClientBeanCreatedEventListener.class);
 
     private final AwsSdkTelemetry awsSdkTelemetry;
 
     /**
-     *
      * @param awsSdkTelemetry AWS SDK telemetry
      */
-    public SdkClientBuilderListener(AwsSdkTelemetry awsSdkTelemetry) {
+    public SqsClientBeanCreatedEventListener(AwsSdkTelemetry awsSdkTelemetry) {
         this.awsSdkTelemetry = awsSdkTelemetry;
     }
 
-    /**
-     * Add an OpenTelemetry execution interceptor to {@link SdkClientBuilder}.
-     *
-     * @param event bean created event
-     * @return sdk client builder
-     */
     @Override
-    public SdkClientBuilder<?, ?> onCreated(BeanCreatedEvent<SdkClientBuilder<?, ?>> event) {
+    public SqsClient onCreated(BeanCreatedEvent<SqsClient> event) {
         if (LOG.isTraceEnabled()) {
-            LOG.trace("Registering OpenTelemetry tracing interceptor to {}", event.getBean().getClass().getSimpleName());
+            LOG.trace("Wrapping OpenTelemetry SQS client {}", event.getBean().getClass().getSimpleName());
         }
-        return event.getBean().overrideConfiguration(builder ->
-            builder.addExecutionInterceptor(awsSdkTelemetry.newExecutionInterceptor()));
+        return awsSdkTelemetry.wrap(event.getBean());
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsClientBeanCreatedEventListener.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsClientBeanCreatedEventListener.java
@@ -37,20 +37,35 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 public class SqsClientBeanCreatedEventListener implements BeanCreatedEventListener<SqsClient> {
     private static final Logger LOG = LoggerFactory.getLogger(SqsClientBeanCreatedEventListener.class);
 
-    private final AwsSdkTelemetry awsSdkTelemetry;
+    private final AwsSdkTelemetryProvider awsSdkTelemetryProvider;
+    private final AwsSdkTelemetryConfiguration awsSdkTelemetryConfiguration;
+    private final MessagingTelemetryConfiguration messagingTelemetryConfiguration;
 
     /**
-     * @param awsSdkTelemetry AWS SDK telemetry
+     * @param awsSdkTelemetryProvider AWS SDK telemetry provider
+     * @param awsSdkTelemetryConfiguration AWS SDK instrumentation configuration
+     * @param messagingTelemetryConfiguration messaging instrumentation configuration
      */
-    public SqsClientBeanCreatedEventListener(AwsSdkTelemetry awsSdkTelemetry) {
-        this.awsSdkTelemetry = awsSdkTelemetry;
+    public SqsClientBeanCreatedEventListener(AwsSdkTelemetryProvider awsSdkTelemetryProvider,
+                                             AwsSdkTelemetryConfiguration awsSdkTelemetryConfiguration,
+                                             MessagingTelemetryConfiguration messagingTelemetryConfiguration) {
+        this.awsSdkTelemetryProvider = awsSdkTelemetryProvider;
+        this.awsSdkTelemetryConfiguration = awsSdkTelemetryConfiguration;
+        this.messagingTelemetryConfiguration = messagingTelemetryConfiguration;
     }
 
     @Override
     public SqsClient onCreated(BeanCreatedEvent<SqsClient> event) {
+        if (!shouldWrap()) {
+            return event.getBean();
+        }
         if (LOG.isTraceEnabled()) {
             LOG.trace("Wrapping OpenTelemetry SQS client {}", event.getBean().getClass().getSimpleName());
         }
-        return awsSdkTelemetry.wrap(event.getBean());
+        return awsSdkTelemetryProvider.wrap(event.getBean());
+    }
+
+    private boolean shouldWrap() {
+        return awsSdkTelemetryConfiguration.isExperimentalUsePropagatorForMessaging() || messagingTelemetryConfiguration.isEnabled();
     }
 }

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsClientBeanCreatedEventListener.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/xray/SqsClientBeanCreatedEventListener.java
@@ -62,7 +62,7 @@ public class SqsClientBeanCreatedEventListener implements BeanCreatedEventListen
         if (LOG.isTraceEnabled()) {
             LOG.trace("Wrapping OpenTelemetry SQS client {}", event.getBean().getClass().getSimpleName());
         }
-        return awsSdkTelemetryProvider.wrap(event.getBean());
+        return awsSdkTelemetryProvider.withTelemetry(awsSdkTelemetry -> awsSdkTelemetry.wrap(event.getBean()));
     }
 
     private boolean shouldWrap() {

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryNoSqsClasspathSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/xray/AwsSdkTelemetryNoSqsClasspathSpec.groovy
@@ -1,0 +1,61 @@
+package io.micronaut.tracing.opentelemetry.xray
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class AwsSdkTelemetryNoSqsClasspathSpec extends Specification {
+
+    void "aws sdk telemetry beans can start without sqs classes"() {
+        given:
+        ClassLoader noSqsClassLoader = new NoSqsClassLoader(getClass().classLoader)
+        ApplicationContext context
+
+        when:
+        context = ApplicationContext.builder()
+                .classLoader(noSqsClassLoader)
+                .start()
+
+        then:
+        !isClassPresent(noSqsClassLoader, 'software.amazon.awssdk.services.sqs.SqsClient')
+
+        and:
+        context.containsBean(AwsSdkTelemetryProvider)
+        context.containsBean(SdkClientBuilderListener)
+        !awsSdkTelemetryProviderLeaksSqsTypes()
+
+        cleanup:
+        context?.close()
+    }
+
+    private static boolean isClassPresent(ClassLoader classLoader, String name) {
+        try {
+            classLoader.loadClass(name)
+            return true
+        } catch (ClassNotFoundException ignored) {
+            return false
+        }
+    }
+
+    private static boolean awsSdkTelemetryProviderLeaksSqsTypes() {
+        AwsSdkTelemetryProvider.getDeclaredMethods().any { method ->
+            method.getReturnType().getName().startsWith('software.amazon.awssdk.services.sqs.') ||
+                    method.getParameterTypes().any { it.getName().startsWith('software.amazon.awssdk.services.sqs.') }
+        }
+    }
+
+    private static final class NoSqsClassLoader extends ClassLoader {
+        private static final String SQS_PACKAGE = 'software.amazon.awssdk.services.sqs.'
+
+        NoSqsClassLoader(ClassLoader parent) {
+            super(parent)
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith(SQS_PACKAGE)) {
+                throw new ClassNotFoundException(name)
+            }
+            return super.loadClass(name, resolve)
+        }
+    }
+}

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/xray/SdkClientBuilderListenerSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/xray/SdkClientBuilderListenerSpec.groovy
@@ -1,9 +1,20 @@
 package io.micronaut.tracing.opentelemetry.xray
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry
 import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.SqsClient
 import spock.lang.Specification
+
+import java.lang.reflect.Field
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Proxy
 
 @MicronautTest(startApplication = false)
 class SdkClientBuilderListenerSpec extends Specification {
@@ -16,4 +27,100 @@ class SdkClientBuilderListenerSpec extends Specification {
         beanContext.containsBean(SdkClientBuilderListener)
     }
 
+    void "aws sdk telemetry uses messaging instrumentation configuration"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                'otel.instrumentation.aws-sdk.experimental-span-attributes'                : true,
+                'otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging'   : true,
+                'otel.instrumentation.messaging.experimental.receive-telemetry.enabled'    : true
+        ])
+
+        expect:
+        context.getBean(AwsSdkTelemetryConfiguration).experimentalSpanAttributes
+        context.getBean(AwsSdkTelemetryConfiguration).experimentalUsePropagatorForMessaging
+        context.getBean(MessagingTelemetryConfiguration).enabled
+
+        when:
+        Object captureExperimentalSpanAttributes = field(context.getBean(AwsSdkTelemetry), 'captureExperimentalSpanAttributes')
+        Object messagingPropagator = field(context.getBean(AwsSdkTelemetry), 'messagingPropagator')
+
+        then:
+        assertTelemetryConfigured(captureExperimentalSpanAttributes, messagingPropagator)
+
+        cleanup:
+        context.close()
+    }
+
+    void "sqs clients are wrapped for message propagation"() {
+        given:
+        SqsClientFactory.reset()
+        ApplicationContext context = ApplicationContext.run('spec.name': 'SdkClientBuilderListenerSpec')
+
+        expect:
+        context.containsBean(SqsClientBeanCreatedEventListener)
+        context.containsBean(SqsAsyncClientBeanCreatedEventListener)
+        !context.getBean(SqsClient).is(SqsClientFactory.sqsClient)
+        !context.getBean(SqsAsyncClient).is(SqsClientFactory.sqsAsyncClient)
+
+        cleanup:
+        context.close()
+        SqsClientFactory.reset()
+    }
+
+    private static Object field(Object bean, String name) {
+        Field field = AwsSdkTelemetry.class.getDeclaredField(name)
+        field.accessible = true
+        field.get(bean)
+    }
+
+    private static boolean assertTelemetryConfigured(Object captureExperimentalSpanAttributes, Object messagingPropagator) {
+        if (captureExperimentalSpanAttributes != Boolean.TRUE) {
+            throw new AssertionError("captureExperimentalSpanAttributes was ${captureExperimentalSpanAttributes}")
+        }
+        if (messagingPropagator == null) {
+            throw new AssertionError("messagingPropagator was null")
+        }
+        true
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = "SdkClientBuilderListenerSpec")
+    static class SqsClientFactory {
+        static SqsClient sqsClient
+        static SqsAsyncClient sqsAsyncClient
+
+        @Singleton
+        SqsClient sqsClient() {
+            sqsClient = proxy(SqsClient)
+        }
+
+        @Singleton
+        SqsAsyncClient sqsAsyncClient() {
+            sqsAsyncClient = proxy(SqsAsyncClient)
+        }
+
+        private static void reset() {
+            sqsClient = null
+            sqsAsyncClient = null
+        }
+
+        private static <T> T proxy(Class<T> type) {
+            Proxy.newProxyInstance(type.classLoader, [type] as Class[], { Object proxy, java.lang.reflect.Method method, Object[] args ->
+                switch (method.name) {
+                    case 'close':
+                        return null
+                    case 'equals':
+                        return proxy.is(args[0])
+                    case 'hashCode':
+                        return System.identityHashCode(proxy)
+                    case 'serviceName':
+                        return 'sqs'
+                    case 'toString':
+                        return "test ${type.simpleName}"
+                    default:
+                        throw new UnsupportedOperationException(method.name)
+                }
+            } as InvocationHandler) as T
+        }
+    }
 }

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/xray/SdkClientBuilderListenerSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/xray/SdkClientBuilderListenerSpec.groovy
@@ -3,16 +3,29 @@ package io.micronaut.tracing.opentelemetry.xray
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Replaces
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry
+import io.micronaut.tracing.opentelemetry.DefaultOpenTelemetryFactory
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Scope
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import software.amazon.awssdk.core.SdkRequest
+import software.amazon.awssdk.core.interceptor.Context as AwsInterceptorContext
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import spock.lang.Specification
 
-import java.lang.reflect.Field
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Proxy
 
@@ -39,13 +52,48 @@ class SdkClientBuilderListenerSpec extends Specification {
         context.getBean(AwsSdkTelemetryConfiguration).experimentalSpanAttributes
         context.getBean(AwsSdkTelemetryConfiguration).experimentalUsePropagatorForMessaging
         context.getBean(MessagingTelemetryConfiguration).enabled
+        context.getBean(AwsSdkTelemetryProvider)
+
+        cleanup:
+        context.close()
+    }
+
+    void "aws sdk telemetry injects configured propagator into sqs message attributes"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name'                                                            : 'SdkClientBuilderListenerSpec',
+                'otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging': true
+        ])
+        ExecutionInterceptor interceptor = context.getBean(AwsSdkTelemetryProvider).newExecutionInterceptor()
+        SendMessageRequest request = SendMessageRequest.builder()
+                .queueUrl('https://sqs.us-east-1.amazonaws.com/123456789012/test')
+                .messageBody('test')
+                .build()
 
         when:
-        Object captureExperimentalSpanAttributes = field(context.getBean(AwsSdkTelemetry), 'captureExperimentalSpanAttributes')
-        Object messagingPropagator = field(context.getBean(AwsSdkTelemetry), 'messagingPropagator')
+        SendMessageRequest modifiedRequest = modifyRequestWithCurrentSpan(context.getBean(OpenTelemetry), interceptor, request)
 
         then:
-        assertTelemetryConfigured(captureExperimentalSpanAttributes, messagingPropagator)
+        modifiedRequest.messageAttributes().containsKey('traceparent')
+
+        cleanup:
+        context.close()
+    }
+
+    void "aws sdk telemetry does not inject configured propagator into sqs message attributes by default"() {
+        given:
+        ApplicationContext context = ApplicationContext.run('spec.name': 'SdkClientBuilderListenerSpec')
+        ExecutionInterceptor interceptor = context.getBean(AwsSdkTelemetryProvider).newExecutionInterceptor()
+        SendMessageRequest request = SendMessageRequest.builder()
+                .queueUrl('https://sqs.us-east-1.amazonaws.com/123456789012/test')
+                .messageBody('test')
+                .build()
+
+        when:
+        SendMessageRequest modifiedRequest = modifyRequestWithCurrentSpan(context.getBean(OpenTelemetry), interceptor, request)
+
+        then:
+        !modifiedRequest.messageAttributes().containsKey('traceparent')
 
         cleanup:
         context.close()
@@ -54,7 +102,11 @@ class SdkClientBuilderListenerSpec extends Specification {
     void "sqs clients are wrapped for message propagation"() {
         given:
         SqsClientFactory.reset()
-        ApplicationContext context = ApplicationContext.run('spec.name': 'SdkClientBuilderListenerSpec')
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name'                                                            : 'SdkClientBuilderListenerSpec',
+                'otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging': true,
+                'otel.instrumentation.messaging.experimental.receive-telemetry.enabled' : true
+        ])
 
         expect:
         context.containsBean(SqsClientBeanCreatedEventListener)
@@ -67,24 +119,78 @@ class SdkClientBuilderListenerSpec extends Specification {
         SqsClientFactory.reset()
     }
 
-    private static Object field(Object bean, String name) {
-        Field field = AwsSdkTelemetry.class.getDeclaredField(name)
-        field.accessible = true
-        field.get(bean)
+    void "sqs clients are wrapped when receive telemetry is enabled"() {
+        given:
+        SqsClientFactory.reset()
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name'                                                           : 'SdkClientBuilderListenerSpec',
+                'otel.instrumentation.messaging.experimental.receive-telemetry.enabled': true
+        ])
+
+        expect:
+        context.containsBean(SqsClientBeanCreatedEventListener)
+        context.containsBean(SqsAsyncClientBeanCreatedEventListener)
+        !context.getBean(SqsClient).is(SqsClientFactory.sqsClient)
+        !context.getBean(SqsAsyncClient).is(SqsClientFactory.sqsAsyncClient)
+
+        cleanup:
+        context.close()
+        SqsClientFactory.reset()
     }
 
-    private static boolean assertTelemetryConfigured(Object captureExperimentalSpanAttributes, Object messagingPropagator) {
-        if (captureExperimentalSpanAttributes != Boolean.TRUE) {
-            throw new AssertionError("captureExperimentalSpanAttributes was ${captureExperimentalSpanAttributes}")
+    void "sqs clients are wrapped when messaging propagator is enabled"() {
+        given:
+        SqsClientFactory.reset()
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name'                                                            : 'SdkClientBuilderListenerSpec',
+                'otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging': true
+        ])
+
+        expect:
+        context.containsBean(SqsClientBeanCreatedEventListener)
+        context.containsBean(SqsAsyncClientBeanCreatedEventListener)
+        !context.getBean(SqsClient).is(SqsClientFactory.sqsClient)
+        !context.getBean(SqsAsyncClient).is(SqsClientFactory.sqsAsyncClient)
+
+        cleanup:
+        context.close()
+        SqsClientFactory.reset()
+    }
+
+    void "sqs clients are not wrapped by default"() {
+        given:
+        SqsClientFactory.reset()
+        ApplicationContext context = ApplicationContext.run('spec.name': 'SdkClientBuilderListenerSpec')
+
+        expect:
+        context.containsBean(SqsClientBeanCreatedEventListener)
+        context.containsBean(SqsAsyncClientBeanCreatedEventListener)
+        context.getBean(SqsClient).is(SqsClientFactory.sqsClient)
+        context.getBean(SqsAsyncClient).is(SqsClientFactory.sqsAsyncClient)
+
+        cleanup:
+        context.close()
+        SqsClientFactory.reset()
+    }
+
+    private static SendMessageRequest modifyRequestWithCurrentSpan(OpenTelemetry openTelemetry,
+                                                                   ExecutionInterceptor interceptor,
+                                                                   SendMessageRequest request) {
+        Span span = openTelemetry.getTracer(SdkClientBuilderListenerSpec.name).spanBuilder('parent').startSpan()
+        try (Scope ignored = span.makeCurrent()) {
+            return (SendMessageRequest) interceptor.modifyRequest(modifyRequestContext(request), new ExecutionAttributes())
+        } finally {
+            span.end()
         }
-        if (messagingPropagator == null) {
-            throw new AssertionError("messagingPropagator was null")
-        }
-        true
+    }
+
+    private static AwsInterceptorContext.ModifyRequest modifyRequestContext(SdkRequest request) {
+        [request: { request }] as AwsInterceptorContext.ModifyRequest
     }
 
     @Factory
     @Requires(property = "spec.name", value = "SdkClientBuilderListenerSpec")
+    @Replaces(factory = DefaultOpenTelemetryFactory)
     static class SqsClientFactory {
         static SqsClient sqsClient
         static SqsAsyncClient sqsAsyncClient
@@ -121,6 +227,15 @@ class SdkClientBuilderListenerSpec extends Specification {
                         throw new UnsupportedOperationException(method.name)
                 }
             } as InvocationHandler) as T
+        }
+
+        @Singleton
+        @Primary
+        OpenTelemetry openTelemetry() {
+            OpenTelemetrySdk.builder()
+                    .setTracerProvider(SdkTracerProvider.builder().build())
+                    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                    .build()
         }
     }
 }


### PR DESCRIPTION
## Summary
- configure AWS SDK OpenTelemetry instrumentation from the messaging-related `otel.instrumentation.*` properties
- wrap `SqsClient` and `SqsAsyncClient` beans for SQS message propagation only when messaging propagation or receive telemetry is enabled
- keep the raw AWS SDK telemetry instrumentation behind an internal provider bean
- add focused tests for SQS client wrapping and AWS SDK telemetry propagation behavior
- document the SQS propagation and receive-telemetry properties

## Verification
- `./gradlew :micronaut-tracing-opentelemetry:test --tests 'io.micronaut.tracing.opentelemetry.xray.SdkClientBuilderListenerSpec' --rerun-tasks`
- `./gradlew :micronaut-tracing-opentelemetry:check`
- `./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew publishGuide`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/717
