### PR TITLE
Fix nested OpenTelemetry map properties

### DIFF
--- a/src/main/docs/guide/opentelemetry.adoc
+++ b/src/main/docs/guide/opentelemetry.adoc
@@ -11,6 +11,22 @@ This keeps OpenTelemetry instrumentation, semantic conventions, SDK, and exporte
 
 Standard OpenTelemetry resource configuration is also supported. For example, you can set `otel.resource.attributes=deployment.environment=prod,service.namespace=payments` or use the equivalent `OTEL_RESOURCE_ATTRIBUTES` environment variable.
 
+Map-style OpenTelemetry configuration can also use nested Micronaut configuration properties.
+For example:
+
+[configuration]
+----
+otel:
+  resource:
+    attributes:
+      service.name: orders
+      deployment.environment: prod
+  exporter:
+    otlp:
+      headers:
+        Authorization: "Bearer token"
+----
+
 == OpenTelemetry annotations
 
 The pkg:tracing.opentelemetry.processing[] package contains transformers and mappers that enables usage of Open Telemetry annotations.

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -17,9 +17,15 @@ package io.micronaut.tracing.opentelemetry;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.conventions.StringConvention;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -58,6 +64,9 @@ public class DefaultOpenTelemetryFactory {
     private static final String DEFAULT_LOGS_EXPORTER = "otel.logs.exporter";
     private static final String REGISTER_GLOBAL = "otel.register.global";
     private static final String NONE = "none";
+    private static final ArgumentConversionContext<Map<String, Object>> OTEL_PROPERTIES = ConversionContext.of(
+        Argument.mapOf(String.class, Object.class).withAnnotationMetadata(mapFormatMetadata())
+    );
     private static final List<String> MAP_PROPERTY_KEYS = Collections.unmodifiableList(Arrays.asList(
         RESOURCE_ATTRIBUTES_KEY,
         "otel.exporter.otlp.headers",
@@ -144,7 +153,9 @@ public class DefaultOpenTelemetryFactory {
         collapseMapProperties(otel);
 
         if (!hasServiceName(otel)) {
-            otel.put(SERVICE_NAME_KEY, applicationConfiguration.getName().orElse(""));
+            applicationConfiguration.getName()
+                .filter(name -> !isBlank(name))
+                .ifPresent(name -> otel.put(SERVICE_NAME_KEY, name));
         }
 
         return otel;
@@ -235,7 +246,7 @@ public class DefaultOpenTelemetryFactory {
     }
 
     private static Map<String, String> resolveOtelProperties(Environment environment) {
-        Map<String, String> otel = environment.getProperties("otel", StringConvention.RAW).entrySet().stream().collect(
+        Map<String, String> otel = environment.getProperty("otel", OTEL_PROPERTIES).orElse(Collections.emptyMap()).entrySet().stream().collect(
             Collectors.toMap(
                 entry -> "otel." + normalizeOtelProperty(entry.getKey()),
                 entry -> String.valueOf(entry.getValue()),
@@ -251,6 +262,15 @@ public class DefaultOpenTelemetryFactory {
 
     private static String normalizeOtelProperty(String property) {
         return property.toLowerCase(Locale.ENGLISH).replace('_', '.');
+    }
+
+    private static AnnotationMetadata mapFormatMetadata() {
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata();
+        metadata.addAnnotation(MapFormat.class.getName(), Map.of(
+            "transformation", MapFormat.MapTransformation.FLAT,
+            "keyFormat", StringConvention.RAW
+        ));
+        return metadata;
     }
 
     /**

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -45,6 +45,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -167,15 +168,19 @@ public class DefaultOpenTelemetryFactory {
             Map<String, String> nestedValues = removeNestedValues(otel, mapPropertyKey);
             if (!nestedValues.isEmpty()) {
                 String nestedConfig = toMapProperty(nestedValues);
-                otel.compute(
-                    mapPropertyKey,
-                    (key, value) -> {
-                        String normalizedValue = normalizeMapPropertyValue(value);
-                        return isBlank(normalizedValue) ? nestedConfig : normalizedValue + "," + nestedConfig;
-                    }
-                );
+                appendMapProperty(otel, mapPropertyKey, nestedConfig);
             }
         }
+    }
+
+    private static void appendMapProperty(Map<String, String> otel, String mapPropertyKey, String nestedConfig) {
+        otel.compute(
+            mapPropertyKey,
+            (key, value) -> {
+                String normalizedValue = normalizeMapPropertyValue(value);
+                return isBlank(normalizedValue) ? nestedConfig : normalizedValue + "," + nestedConfig;
+            }
+        );
     }
 
     private static String normalizeMapPropertyValue(@Nullable String value) {
@@ -247,18 +252,44 @@ public class DefaultOpenTelemetryFactory {
     }
 
     private static Map<String, String> resolveOtelProperties(Environment environment) {
-        Map<String, String> otel = environment.getProperty("otel", OTEL_PROPERTIES).orElse(Collections.emptyMap()).entrySet().stream().collect(
-            Collectors.toMap(
+        Map<String, String> otel = environment.getProperty("otel", OTEL_PROPERTIES).orElse(Collections.emptyMap()).entrySet().stream()
+            .filter(entry -> !isNestedMapProperty(entry.getKey()))
+            .collect(Collectors.toMap(
                 entry -> OTEL_PREFIX + normalizeOtelProperty(entry.getKey()),
                 entry -> String.valueOf(entry.getValue()),
                 (existing, replacement) -> existing,
                 LinkedHashMap::new
-            )
-        );
+            ));
         environment.getProperty(RESOURCE_ATTRIBUTES_KEY, String.class).ifPresent(attributes ->
             otel.putIfAbsent(RESOURCE_ATTRIBUTES_KEY, attributes)
         );
+        MAP_PROPERTY_KEYS.forEach(mapPropertyKey ->
+            getNestedMapProperty(environment, mapPropertyKey)
+                .filter(properties -> !properties.isEmpty())
+                .ifPresent(properties -> appendMapProperty(otel, mapPropertyKey, toMapProperty(properties)))
+        );
         return otel;
+    }
+
+    private static Optional<Map<String, String>> getNestedMapProperty(Environment environment, String mapPropertyKey) {
+        Map<String, Object> properties = environment.getProperties(mapPropertyKey, StringConvention.RAW);
+        if (properties.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(properties.entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> String.valueOf(entry.getValue()),
+                (existing, replacement) -> existing,
+                LinkedHashMap::new
+            )));
+    }
+
+    private static boolean isNestedMapProperty(String property) {
+        String normalized = normalizeOtelProperty(property);
+        return MAP_PROPERTY_KEYS.stream()
+            .map(key -> key.substring(OTEL_PREFIX.length()) + ".")
+            .anyMatch(normalized::startsWith);
     }
 
     private static String normalizeOtelProperty(String property) {

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -32,9 +32,15 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Registers an OpenTelemetry bean.
@@ -52,6 +58,13 @@ public class DefaultOpenTelemetryFactory {
     private static final String DEFAULT_LOGS_EXPORTER = "otel.logs.exporter";
     private static final String REGISTER_GLOBAL = "otel.register.global";
     private static final String NONE = "none";
+    private static final List<String> MAP_PROPERTY_KEYS = Collections.unmodifiableList(Arrays.asList(
+        RESOURCE_ATTRIBUTES_KEY,
+        "otel.exporter.otlp.headers",
+        "otel.exporter.otlp.traces.headers",
+        "otel.exporter.otlp.metrics.headers",
+        "otel.exporter.otlp.logs.headers"
+    ));
 
     /**
      * The OpenTelemetry bean with default values.
@@ -79,9 +92,7 @@ public class DefaultOpenTelemetryFactory {
             return existingGlobalOpenTelemetry;
         }
 
-        Map<String, String> otel = resolveOtelProperties(environment);
-
-        applicationConfiguration.getName().ifPresent(name -> otel.putIfAbsent(SERVICE_NAME_KEY, name));
+        Map<String, String> otel = resolveOpenTelemetryProperties(applicationConfiguration, resolveOtelProperties(environment));
         otel.putIfAbsent(DEFAULT_TRACES_EXPORTER, NONE);
         otel.putIfAbsent(DEFAULT_METRICS_EXPORTER, NONE);
         otel.putIfAbsent(DEFAULT_LOGS_EXPORTER, NONE);
@@ -121,6 +132,98 @@ public class DefaultOpenTelemetryFactory {
         return sdk.build().getOpenTelemetrySdk();
     }
 
+    static Map<String, String> resolveOpenTelemetryProperties(ApplicationConfiguration applicationConfiguration,
+                                                              Map<String, String> otelConfig) {
+        Map<String, String> otel = otelConfig.entrySet().stream().collect(Collectors.toMap(
+            e -> e.getKey().startsWith("otel.") ? e.getKey() : "otel." + e.getKey(),
+            Map.Entry::getValue,
+            (left, right) -> right,
+            LinkedHashMap::new
+        ));
+
+        collapseMapProperties(otel);
+
+        if (!hasServiceName(otel)) {
+            otel.put(SERVICE_NAME_KEY, applicationConfiguration.getName().orElse(""));
+        }
+
+        return otel;
+    }
+
+    private static void collapseMapProperties(Map<String, String> otel) {
+        for (String mapPropertyKey : MAP_PROPERTY_KEYS) {
+            Map<String, String> nestedValues = removeNestedValues(otel, mapPropertyKey);
+            if (!nestedValues.isEmpty()) {
+                String nestedConfig = toMapProperty(nestedValues);
+                otel.compute(
+                    mapPropertyKey,
+                    (key, value) -> {
+                        String normalizedValue = normalizeMapPropertyValue(value);
+                        return isBlank(normalizedValue) ? nestedConfig : normalizedValue + "," + nestedConfig;
+                    }
+                );
+            }
+        }
+    }
+
+    private static String normalizeMapPropertyValue(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        while (!normalized.isEmpty() && normalized.charAt(normalized.length() - 1) == ',') {
+            normalized = normalized.substring(0, normalized.length() - 1).trim();
+        }
+        return normalized;
+    }
+
+    private static Map<String, String> removeNestedValues(Map<String, String> otel, String mapPropertyKey) {
+        String prefix = mapPropertyKey + ".";
+        Map<String, String> nestedValues = new LinkedHashMap<>();
+        otel.entrySet().removeIf(entry -> {
+            if (entry.getKey().startsWith(prefix)) {
+                nestedValues.put(entry.getKey().substring(prefix.length()), entry.getValue());
+                return true;
+            }
+            return false;
+        });
+        return nestedValues;
+    }
+
+    private static String toMapProperty(Map<String, String> nestedValues) {
+        return nestedValues.entrySet().stream()
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining(","));
+    }
+
+    private static boolean hasServiceName(Map<String, String> otel) {
+        String serviceName = otel.get(SERVICE_NAME_KEY);
+        if (!isBlank(serviceName)) {
+            return true;
+        }
+        String resourceAttributes = otel.get(RESOURCE_ATTRIBUTES_KEY);
+        return resourceAttributes != null && Stream.of(resourceAttributes.split(","))
+            .map(String::trim)
+            .anyMatch(DefaultOpenTelemetryFactory::hasNonBlankServiceNameAttribute);
+    }
+
+    private static boolean hasNonBlankServiceNameAttribute(String entry) {
+        int separatorIndex = entry.indexOf('=');
+        if (separatorIndex < 0) {
+            return false;
+        }
+        String key = entry.substring(0, separatorIndex).trim();
+        if (!"service.name".equals(key)) {
+            return false;
+        }
+        String value = entry.substring(separatorIndex + 1).trim();
+        return !isBlank(value);
+    }
+
+    private static boolean isBlank(@Nullable String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
     @Nullable
     private OpenTelemetry existingGlobalOpenTelemetry() {
         if (!GlobalOpenTelemetry.isSet()) {
@@ -131,12 +234,13 @@ public class DefaultOpenTelemetryFactory {
         return globalOpenTelemetry.getTracerProvider() == TracerProvider.noop() ? null : globalOpenTelemetry;
     }
 
-    private Map<String, String> resolveOtelProperties(Environment environment) {
+    private static Map<String, String> resolveOtelProperties(Environment environment) {
         Map<String, String> otel = environment.getProperties("otel", StringConvention.RAW).entrySet().stream().collect(
-            java.util.stream.Collectors.toMap(
+            Collectors.toMap(
                 entry -> "otel." + normalizeOtelProperty(entry.getKey()),
                 entry -> String.valueOf(entry.getValue()),
-                (existing, replacement) -> existing
+                (existing, replacement) -> existing,
+                LinkedHashMap::new
             )
         );
         environment.getProperty(RESOURCE_ATTRIBUTES_KEY, String.class).ifPresent(attributes ->
@@ -145,7 +249,7 @@ public class DefaultOpenTelemetryFactory {
         return otel;
     }
 
-    private String normalizeOtelProperty(String property) {
+    private static String normalizeOtelProperty(String property) {
         return property.toLowerCase(Locale.ENGLISH).replace('_', '.');
     }
 

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -66,9 +66,7 @@ public class DefaultOpenTelemetryFactory {
     private static final String DEFAULT_LOGS_EXPORTER = "otel.logs.exporter";
     private static final String REGISTER_GLOBAL = "otel.register.global";
     private static final String NONE = "none";
-    private static final ArgumentConversionContext<Map<String, Object>> OTEL_PROPERTIES = ConversionContext.of(
-        Argument.mapOf(String.class, Object.class).withAnnotationMetadata(mapFormatMetadata())
-    );
+    private static final ArgumentConversionContext<Map<String, Object>> OTEL_PROPERTIES = mapPropertyConversionContext();
     private static final List<String> MAP_PROPERTY_KEYS = Collections.unmodifiableList(Arrays.asList(
         RESOURCE_ATTRIBUTES_KEY,
         "otel.exporter.otlp.headers",
@@ -272,17 +270,27 @@ public class DefaultOpenTelemetryFactory {
     }
 
     private static Optional<Map<String, String>> getNestedMapProperty(Environment environment, String mapPropertyKey) {
-        Map<String, Object> properties = environment.getProperties(mapPropertyKey, StringConvention.RAW);
-        if (properties.isEmpty()) {
-            return Optional.empty();
+        // Preserve mixed aggregate+nested configuration; MapFormat conversion returns the aggregate value only.
+        if (environment.getProperty(mapPropertyKey, String.class).isPresent()) {
+            Map<String, Object> properties = environment.getProperties(mapPropertyKey, StringConvention.RAW);
+            if (properties.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(toStringMap(properties));
         }
-        return Optional.of(properties.entrySet().stream()
+        return environment.getProperty(mapPropertyKey, OTEL_PROPERTIES)
+            .filter(properties -> !properties.isEmpty())
+            .map(DefaultOpenTelemetryFactory::toStringMap);
+    }
+
+    private static Map<String, String> toStringMap(Map<String, Object> properties) {
+        return properties.entrySet().stream()
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
                 entry -> String.valueOf(entry.getValue()),
                 (existing, replacement) -> existing,
                 LinkedHashMap::new
-            )));
+            ));
     }
 
     private static boolean isNestedMapProperty(String property) {
@@ -294,6 +302,12 @@ public class DefaultOpenTelemetryFactory {
 
     private static String normalizeOtelProperty(String property) {
         return property.toLowerCase(Locale.ENGLISH).replace('_', '.');
+    }
+
+    private static ArgumentConversionContext<Map<String, Object>> mapPropertyConversionContext() {
+        return ConversionContext.of(
+            Argument.mapOf(String.class, Object.class).withAnnotationMetadata(mapFormatMetadata())
+        );
     }
 
     private static AnnotationMetadata mapFormatMetadata() {

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactory.java
@@ -57,6 +57,7 @@ import java.util.stream.Stream;
 @Factory
 public class DefaultOpenTelemetryFactory {
 
+    private static final String OTEL_PREFIX = "otel.";
     private static final String SERVICE_NAME_KEY = "otel.service.name";
     private static final String RESOURCE_ATTRIBUTES_KEY = "otel.resource.attributes";
     private static final String DEFAULT_TRACES_EXPORTER = "otel.traces.exporter";
@@ -144,7 +145,7 @@ public class DefaultOpenTelemetryFactory {
     static Map<String, String> resolveOpenTelemetryProperties(ApplicationConfiguration applicationConfiguration,
                                                               Map<String, String> otelConfig) {
         Map<String, String> otel = otelConfig.entrySet().stream().collect(Collectors.toMap(
-            e -> e.getKey().startsWith("otel.") ? e.getKey() : "otel." + e.getKey(),
+            e -> e.getKey().startsWith(OTEL_PREFIX) ? e.getKey() : OTEL_PREFIX + e.getKey(),
             Map.Entry::getValue,
             (left, right) -> right,
             LinkedHashMap::new
@@ -248,7 +249,7 @@ public class DefaultOpenTelemetryFactory {
     private static Map<String, String> resolveOtelProperties(Environment environment) {
         Map<String, String> otel = environment.getProperty("otel", OTEL_PROPERTIES).orElse(Collections.emptyMap()).entrySet().stream().collect(
             Collectors.toMap(
-                entry -> "otel." + normalizeOtelProperty(entry.getKey()),
+                entry -> OTEL_PREFIX + normalizeOtelProperty(entry.getKey()),
                 entry -> String.valueOf(entry.getValue()),
                 (existing, replacement) -> existing,
                 LinkedHashMap::new

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
@@ -93,14 +93,42 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
 
         then:
         configProperties.getMap('otel.exporter.otlp.headers') == [
-                'authorization': 'Bearer token',
-                'content-type' : 'application/x-protobuf'
+                'Authorization': 'Bearer token',
+                'Content-Type' : 'application/x-protobuf'
         ]
         configProperties.getMap('otel.resource.attributes') == [
                 'service.name': 'explicit-service',
                 'environment' : 'test'
         ]
         configProperties.getString('otel.service.name') == null
+
+        cleanup:
+        context.close()
+    }
+
+    void "existing and nested Micronaut map properties are visible as OpenTelemetry map properties"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name'                                : 'DefaultOpenTelemetryFactorySpec',
+                'otel.exporter.otlp.headers'               : 'Existing=present, ',
+                'otel.exporter.otlp.headers.Authorization' : 'Bearer token',
+                'otel.resource.attributes'                 : 'deployment.environment=prod, ',
+                'otel.resource.attributes.service.name'    : 'explicit-service'
+        ])
+
+        when:
+        context.getBean(OpenTelemetry)
+        ConfigProperties configProperties = CONFIG_PROPERTIES.get()
+
+        then:
+        configProperties.getMap('otel.exporter.otlp.headers') == [
+                'Existing'     : 'present',
+                'Authorization': 'Bearer token'
+        ]
+        configProperties.getMap('otel.resource.attributes') == [
+                'deployment.environment': 'prod',
+                'service.name'          : 'explicit-service'
+        ]
 
         cleanup:
         context.close()

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
@@ -1,8 +1,10 @@
 package io.micronaut.tracing.opentelemetry
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
+import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.tracing.annotation.NewSpan
 import io.micronaut.tracing.annotation.SpanTag
 import io.opentelemetry.api.GlobalOpenTelemetry
@@ -10,15 +12,20 @@ import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.TracerProvider
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import jakarta.inject.Singleton
 import spock.lang.Specification
 
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.BiFunction
+
 class DefaultOpenTelemetryFactorySpec extends Specification {
 
     private static final AttributeKey<String> VALUE = AttributeKey.stringKey("value")
+    private static final AtomicReference<ConfigProperties> CONFIG_PROPERTIES = new AtomicReference<>()
 
     ApplicationContext context
     OpenTelemetrySdk globalOpenTelemetry
@@ -27,6 +34,7 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
         context?.close()
         globalOpenTelemetry?.close()
         GlobalOpenTelemetry.resetForTest()
+        CONFIG_PROPERTIES.set(null)
     }
 
     void "uses pre-registered GlobalOpenTelemetry for Micronaut spans"() {
@@ -69,6 +77,74 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
         context.getBean(OpenTelemetry).tracerProvider != TracerProvider.noop()
     }
 
+    void "nested Micronaut properties are visible as OpenTelemetry map properties"() {
+        when:
+        context = ApplicationContext.run([
+            'spec.name'                                  : 'DefaultOpenTelemetryFactorySpec',
+            'otel.exporter.otlp.headers.Authorization'   : 'Bearer token',
+            'otel.exporter.otlp.headers.Content-Type'    : 'application/x-protobuf',
+            'otel.resource.attributes.service.name'      : 'explicit-service',
+            'otel.resource.attributes.environment'       : 'test'
+        ])
+
+        context.getBean(OpenTelemetry)
+        ConfigProperties configProperties = CONFIG_PROPERTIES.get()
+
+        then:
+        configProperties.getMap('otel.exporter.otlp.headers') == [
+            'authorization': 'Bearer token',
+            'content-type' : 'application/x-protobuf'
+        ]
+        configProperties.getMap('otel.resource.attributes') == [
+            'service.name': 'explicit-service',
+            'environment' : 'test'
+        ]
+        configProperties.getString('otel.service.name') == null
+    }
+
+    void "nested map properties are converted to OpenTelemetry map property format"() {
+        given:
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration()
+        applicationConfiguration.name = 'default-app'
+
+        when:
+        Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
+            applicationConfiguration,
+            [
+                'exporter.otlp.headers.Authorization'       : 'Bearer token',
+                'exporter.otlp.headers.Content-Type'        : 'application/x-protobuf',
+                'exporter.otlp.traces.headers.Authorization': 'Bearer traces-token',
+                'resource.attributes.service.name'          : 'explicit-service',
+                'resource.attributes.environment'           : 'test',
+                'traces.exporter'                           : 'otlp'
+            ]
+        )
+
+        then:
+        properties['otel.exporter.otlp.headers'] == 'Authorization=Bearer token,Content-Type=application/x-protobuf'
+        properties['otel.exporter.otlp.traces.headers'] == 'Authorization=Bearer traces-token'
+        properties['otel.resource.attributes'] == 'service.name=explicit-service,environment=test'
+        properties['otel.traces.exporter'] == 'otlp'
+        !properties.containsKey('otel.exporter.otlp.headers.Authorization')
+        !properties.containsKey('otel.resource.attributes.service.name')
+        !properties.containsKey('otel.service.name')
+    }
+
+    void "application name is used as default service name when service name is not configured"() {
+        given:
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration()
+        applicationConfiguration.name = 'default-app'
+
+        when:
+        Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
+            applicationConfiguration,
+            [:]
+        )
+
+        then:
+        properties['otel.service.name'] == 'default-app'
+    }
+
     @Requires(property = "spec.name", value = "DefaultOpenTelemetryFactorySpec")
     @Singleton
     static class TestService {
@@ -76,6 +152,21 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
         @NewSpan("invoke")
         String invoke(@SpanTag("value") String value) {
             return value
+        }
+    }
+
+    @Factory
+    @Requires(property = 'spec.name', value = 'DefaultOpenTelemetryFactorySpec')
+    static class ConfigPropertiesCaptureFactory {
+
+        @Singleton
+        OpenTelemetryBuilderCustomizer configPropertiesCapture() {
+            return { builder ->
+                builder.addResourceCustomizer({ resource, configProperties ->
+                    CONFIG_PROPERTIES.set(configProperties)
+                    return resource
+                } as BiFunction)
+            } as OpenTelemetryBuilderCustomizer
         }
     }
 }

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
@@ -78,28 +78,32 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
     }
 
     void "nested Micronaut properties are visible as OpenTelemetry map properties"() {
-        when:
-        context = ApplicationContext.run([
-            'spec.name'                                  : 'DefaultOpenTelemetryFactorySpec',
-            'otel.exporter.otlp.headers.Authorization'   : 'Bearer token',
-            'otel.exporter.otlp.headers.Content-Type'    : 'application/x-protobuf',
-            'otel.resource.attributes.service.name'      : 'explicit-service',
-            'otel.resource.attributes.environment'       : 'test'
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name'                                  : 'DefaultOpenTelemetryFactorySpec',
+                'otel.exporter.otlp.headers.Authorization'   : 'Bearer token',
+                'otel.exporter.otlp.headers.Content-Type'    : 'application/x-protobuf',
+                'otel.resource.attributes.service.name'      : 'explicit-service',
+                'otel.resource.attributes.environment'       : 'test'
         ])
 
+        when:
         context.getBean(OpenTelemetry)
         ConfigProperties configProperties = CONFIG_PROPERTIES.get()
 
         then:
         configProperties.getMap('otel.exporter.otlp.headers') == [
-            'authorization': 'Bearer token',
-            'content-type' : 'application/x-protobuf'
+                'authorization': 'Bearer token',
+                'content-type' : 'application/x-protobuf'
         ]
         configProperties.getMap('otel.resource.attributes') == [
-            'service.name': 'explicit-service',
-            'environment' : 'test'
+                'service.name': 'explicit-service',
+                'environment' : 'test'
         ]
         configProperties.getString('otel.service.name') == null
+
+        cleanup:
+        context.close()
     }
 
     void "nested map properties are converted to OpenTelemetry map property format"() {
@@ -109,15 +113,15 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
 
         when:
         Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
-            applicationConfiguration,
-            [
-                'exporter.otlp.headers.Authorization'       : 'Bearer token',
-                'exporter.otlp.headers.Content-Type'        : 'application/x-protobuf',
-                'exporter.otlp.traces.headers.Authorization': 'Bearer traces-token',
-                'resource.attributes.service.name'          : 'explicit-service',
-                'resource.attributes.environment'           : 'test',
-                'traces.exporter'                           : 'otlp'
-            ]
+                applicationConfiguration,
+                [
+                        'exporter.otlp.headers.Authorization'       : 'Bearer token',
+                        'exporter.otlp.headers.Content-Type'        : 'application/x-protobuf',
+                        'exporter.otlp.traces.headers.Authorization': 'Bearer traces-token',
+                        'resource.attributes.service.name'          : 'explicit-service',
+                        'resource.attributes.environment'           : 'test',
+                        'traces.exporter'                           : 'otlp'
+                ]
         )
 
         then:
@@ -137,22 +141,66 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
 
         when:
         Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
-            applicationConfiguration,
-            [:]
+                applicationConfiguration,
+                [:]
         )
 
         then:
         properties['otel.service.name'] == 'default-app'
     }
 
-    @Requires(property = "spec.name", value = "DefaultOpenTelemetryFactorySpec")
-    @Singleton
-    static class TestService {
+    void "application name is used as default service name when resource service name is blank"() {
+        given:
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration()
+        applicationConfiguration.name = 'default-app'
 
-        @NewSpan("invoke")
-        String invoke(@SpanTag("value") String value) {
-            return value
-        }
+        when:
+        Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
+                applicationConfiguration,
+                [
+                        'resource.attributes.service.name': '  ',
+                        'resource.attributes.environment' : 'test'
+                ]
+        )
+
+        then:
+        properties['otel.resource.attributes'] == 'service.name=  ,environment=test'
+        properties['otel.service.name'] == 'default-app'
+    }
+
+    void "application name replaces blank service name property"() {
+        given:
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration()
+        applicationConfiguration.name = 'default-app'
+
+        when:
+        Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
+                applicationConfiguration,
+                [
+                        'service.name': ' '
+                ]
+        )
+
+        then:
+        properties['otel.service.name'] == 'default-app'
+    }
+
+    void "existing map properties are normalized before nested map properties are appended"() {
+        given:
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration()
+        applicationConfiguration.name = 'default-app'
+
+        when:
+        Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
+                applicationConfiguration,
+                [
+                        'exporter.otlp.headers'              : ' Existing=present, ',
+                        'exporter.otlp.headers.Authorization': 'Bearer token'
+                ]
+        )
+
+        then:
+        properties['otel.exporter.otlp.headers'] == 'Existing=present,Authorization=Bearer token'
     }
 
     @Factory
@@ -167,6 +215,16 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
                     return resource
                 } as BiFunction)
             } as OpenTelemetryBuilderCustomizer
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'DefaultOpenTelemetryFactorySpec')
+    @Singleton
+    static class TestService {
+
+        @NewSpan('invoke')
+        String invoke(@SpanTag('value') String value) {
+            return value
         }
     }
 }

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
@@ -118,6 +118,8 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
                         'exporter.otlp.headers.Authorization'       : 'Bearer token',
                         'exporter.otlp.headers.Content-Type'        : 'application/x-protobuf',
                         'exporter.otlp.traces.headers.Authorization': 'Bearer traces-token',
+                        'exporter.otlp.metrics.headers.Authorization': 'Bearer metrics-token',
+                        'exporter.otlp.logs.headers.Authorization'  : 'Bearer logs-token',
                         'resource.attributes.service.name'          : 'explicit-service',
                         'resource.attributes.environment'           : 'test',
                         'traces.exporter'                           : 'otlp'
@@ -127,6 +129,8 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
         then:
         properties['otel.exporter.otlp.headers'] == 'Authorization=Bearer token,Content-Type=application/x-protobuf'
         properties['otel.exporter.otlp.traces.headers'] == 'Authorization=Bearer traces-token'
+        properties['otel.exporter.otlp.metrics.headers'] == 'Authorization=Bearer metrics-token'
+        properties['otel.exporter.otlp.logs.headers'] == 'Authorization=Bearer logs-token'
         properties['otel.resource.attributes'] == 'service.name=explicit-service,environment=test'
         properties['otel.traces.exporter'] == 'otlp'
         !properties.containsKey('otel.exporter.otlp.headers.Authorization')
@@ -147,6 +151,20 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
 
         then:
         properties['otel.service.name'] == 'default-app'
+    }
+
+    void "service name is not configured when application name is absent"() {
+        given:
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration()
+
+        when:
+        Map<String, String> properties = DefaultOpenTelemetryFactory.resolveOpenTelemetryProperties(
+                applicationConfiguration,
+                [:]
+        )
+
+        then:
+        !properties.containsKey('otel.service.name')
     }
 
     void "application name is used as default service name when resource service name is blank"() {

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/DefaultOpenTelemetryFactorySpec.groovy
@@ -134,6 +134,27 @@ class DefaultOpenTelemetryFactorySpec extends Specification {
         context.close()
     }
 
+    void "nested Micronaut map property overrides duplicate existing OpenTelemetry map property key"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name'                                : 'DefaultOpenTelemetryFactorySpec',
+                'otel.exporter.otlp.headers'               : 'Authorization=old',
+                'otel.exporter.otlp.headers.Authorization' : 'new'
+        ])
+
+        when:
+        context.getBean(OpenTelemetry)
+        ConfigProperties configProperties = CONFIG_PROPERTIES.get()
+
+        then:
+        configProperties.getMap('otel.exporter.otlp.headers') == [
+                'Authorization': 'new'
+        ]
+
+        cleanup:
+        context.close()
+    }
+
     void "nested map properties are converted to OpenTelemetry map property format"() {
         given:
         ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration()


### PR DESCRIPTION
## Summary
- Convert nested Micronaut `otel` map-style configuration into the comma-separated map format expected by OpenTelemetry autoconfigure.
- Apply the conversion to OTLP headers and resource attributes so authorization headers and explicit service attributes are not ignored.
- Treat blank service-name values as missing and normalize existing map properties before appending nested map entries.
- Add focused coverage for direct property conversion, the Micronaut `ApplicationContext` path, blank service names, and existing map-property normalization.

## Verification
- `./gradlew :micronaut-tracing-opentelemetry:test --tests 'io.micronaut.tracing.opentelemetry.DefaultOpenTelemetryFactorySpec'`
- `./gradlew :micronaut-tracing-opentelemetry:test --tests 'io.micronaut.tracing.opentelemetry.DefaultOpenTelemetryFactorySpec' :micronaut-tracing-opentelemetry:check`
- `./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/714
