### PR TITLE
Set OpenTracing HTTP span kind tags

### DIFF
--- a/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/tracing-jaeger/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -82,11 +82,13 @@ class HttpTracingSpec extends Specification {
             serverSpan != null
             serverSpan.tags['foo'] == 'bar'
             serverSpan.tags['http.path'] == '/traced/hello/John'
+            serverSpan.tags['span.kind'] == 'server'
 
             JaegerSpan clientSpan = reporter.spans.find { it.operationName == 'GET /traced/hello/John' && it.tags['http.client'] == true }
             clientSpan != null
             clientSpan.tags['foo'] == null
             clientSpan.tags['http.path'] == '/traced/hello/John'
+            clientSpan.tags['span.kind'] == 'client'
 
             nrOfStartedSpans > 0
             nrOfFinishedSpans == nrOfStartedSpans

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingClientFilter.java
@@ -39,6 +39,8 @@ import static io.micronaut.tracing.opentracing.instrument.http.AbstractOpenTraci
 import static io.micronaut.tracing.opentracing.instrument.http.TraceRequestAttributes.CURRENT_SPAN;
 import static io.micronaut.tracing.opentracing.instrument.http.TraceRequestAttributes.CURRENT_SPAN_CONTEXT;
 import static io.opentracing.propagation.Format.Builtin.HTTP_HEADERS;
+import static io.opentracing.tag.Tags.SPAN_KIND;
+import static io.opentracing.tag.Tags.SPAN_KIND_CLIENT;
 
 /**
  * An HTTP client instrumentation filter that uses Open Tracing.
@@ -81,6 +83,7 @@ public final class OpenTracingClientFilter extends AbstractOpenTracingFilter imp
         }
         Span span = spanBuilder.start();
         span.setTag(TAG_HTTP_CLIENT, true);
+        span.setTag(SPAN_KIND.getKey(), SPAN_KIND_CLIENT);
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/OpenTracingServerFilter.java
@@ -41,6 +41,8 @@ import static io.micronaut.tracing.opentracing.instrument.http.AbstractOpenTraci
 import static io.micronaut.tracing.opentracing.instrument.http.TraceRequestAttributes.CURRENT_SPAN;
 import static io.micronaut.tracing.opentracing.instrument.http.TraceRequestAttributes.CURRENT_SPAN_CONTEXT;
 import static io.opentracing.propagation.Format.Builtin.HTTP_HEADERS;
+import static io.opentracing.tag.Tags.SPAN_KIND;
+import static io.opentracing.tag.Tags.SPAN_KIND_SERVER;
 
 /**
  * An HTTP server instrumentation filter that uses Open Tracing.
@@ -81,6 +83,7 @@ public final class OpenTracingServerFilter extends AbstractOpenTracingFilter imp
 
         Span span = spanBuilder.start();
         span.setTag(TAG_HTTP_SERVER, true);
+        span.setTag(SPAN_KIND.getKey(), SPAN_KIND_SERVER);
         request.setAttribute(CURRENT_SPAN_CONTEXT, span.context());
         request.setAttribute(CURRENT_SPAN, span);
 


### PR DESCRIPTION
## Summary

- Set OpenTracing HTTP server spans to `span.kind=server`.
- Set OpenTracing HTTP client spans to `span.kind=client`.
- Add Jaeger HTTP tracing regression coverage for both emitted span kind values.

## Testing

- `./gradlew :micronaut-tracing-jaeger:test --tests io.micronaut.tracing.jaeger.HttpTracingSpec -q`
- `./gradlew :micronaut-tracing-opentracing:check :micronaut-tracing-jaeger:check -q -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew spotlessCheck :micronaut-tracing-opentracing:check :micronaut-tracing-jaeger:check -q -x japiCmp -x checkVersionCatalogCompatibility`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/659
