### PR TITLE
Document OpenTelemetry dependency alignment

### DIFF
--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -7,7 +7,7 @@ That release moved `@WithSpan` and `@SpanAttribute` from `io.opentelemetry.exten
 
 If your application uses `micronaut-tracing-opentelemetry-annotation` and imports the old package, update those imports to the new package before upgrading to Micronaut Tracing `4.5.0` or newer.
 
-If you upgrade to Micronaut Tracing `4.5.0` independently from the Micronaut Platform version used by your application, import `io.micronaut.tracing:micronaut-tracing-bom:4.5.0` in dependency management.
+If you upgrade to Micronaut Tracing `4.5.0` independently from the Micronaut Platform version used by your application, import the matching `io.micronaut.tracing:micronaut-tracing-bom` version (the same version as your Micronaut Tracing version) in dependency management.
 Applications that keep an older Micronaut Platform-managed tracing BOM while forcing only the Micronaut Tracing OpenTelemetry module version can resolve incompatible OpenTelemetry instrumentation, semantic conventions, SDK, and exporter artifacts.
 
 == Micronaut Tracing 5.0.0-M2 breaking changes

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -7,6 +7,9 @@ That release moved `@WithSpan` and `@SpanAttribute` from `io.opentelemetry.exten
 
 If your application uses `micronaut-tracing-opentelemetry-annotation` and imports the old package, update those imports to the new package before upgrading to Micronaut Tracing `4.5.0` or newer.
 
+If you upgrade to Micronaut Tracing `4.5.0` independently from the Micronaut Platform version used by your application, import `io.micronaut.tracing:micronaut-tracing-bom:4.5.0` in dependency management.
+Applications that keep an older Micronaut Platform-managed tracing BOM while forcing only the Micronaut Tracing OpenTelemetry module version can resolve incompatible OpenTelemetry instrumentation, semantic conventions, SDK, and exporter artifacts.
+
 == Micronaut Tracing 5.0.0-M2 breaking changes
 
 The Micronaut Tracing Zipkin module (`io.micronaut.tracing:micronaut-tracing-zipkin`) has been renamed and separated in two new modules:

--- a/src/main/docs/guide/opentelemetry.adoc
+++ b/src/main/docs/guide/opentelemetry.adoc
@@ -5,8 +5,8 @@ The Micronaut Open Telemetry module uses https://github.com/open-telemetry/opent
 - otel.logs.exporter = none
 - otel.service.name = value of the application.name
 
-OpenTelemetry libraries must be resolved from the same dependency-management line as the Micronaut Tracing OpenTelemetry modules.
-If an application overrides the Micronaut Tracing version supplied by the Micronaut Platform, also import the matching `io.micronaut.tracing:micronaut-tracing-bom` version.
+OpenTelemetry libraries must be resolved using the same BOM or platform dependency management as the Micronaut Tracing OpenTelemetry modules.
+If an application overrides the Micronaut Tracing version supplied by the Micronaut Platform BOM, also import the matching `io.micronaut.tracing:micronaut-tracing-bom` version.
 This keeps OpenTelemetry instrumentation, semantic conventions, SDK, and exporter dependencies aligned.
 
 == OpenTelemetry annotations

--- a/src/main/docs/guide/opentelemetry.adoc
+++ b/src/main/docs/guide/opentelemetry.adoc
@@ -5,7 +5,10 @@ The Micronaut Open Telemetry module uses https://github.com/open-telemetry/opent
 - otel.logs.exporter = none
 - otel.service.name = value of the application.name
 
+OpenTelemetry libraries must be resolved from the same dependency-management line as the Micronaut Tracing OpenTelemetry modules.
+If an application overrides the Micronaut Tracing version supplied by the Micronaut Platform, also import the matching `io.micronaut.tracing:micronaut-tracing-bom` version.
+This keeps OpenTelemetry instrumentation, semantic conventions, SDK, and exporter dependencies aligned.
+
 == OpenTelemetry annotations
 
 The pkg:tracing.opentelemetry.processing[] package contains transformers and mappers that enables usage of Open Telemetry annotations.
-

--- a/src/main/docs/guide/opentelemetry/exporters.adoc
+++ b/src/main/docs/guide/opentelemetry/exporters.adoc
@@ -2,6 +2,9 @@ In your project you can specify exporters that you want to use. The default one 
 
 For each exporter that you want to use you have to specify it inside configuration, and you have to add required dependency:
 
+The versionless exporter dependencies below rely on Micronaut dependency management.
+If you override the Micronaut Tracing version, import the matching `io.micronaut.tracing:micronaut-tracing-bom` as well so exporters use the OpenTelemetry version expected by the tracing instrumentation.
+
 - OpenTelemetry Protocol exporter: `otlp`
 dependency:opentelemetry-exporter-otlp[scope="implementation", groupId="io.opentelemetry"]
 - Logging exporter: `logging`

--- a/src/main/docs/guide/opentelemetry/exporters.adoc
+++ b/src/main/docs/guide/opentelemetry/exporters.adoc
@@ -3,7 +3,7 @@ In your project you can specify exporters that you want to use. The default one 
 For each exporter that you want to use you have to specify it inside configuration, and you have to add required dependency:
 
 The versionless exporter dependencies below rely on Micronaut dependency management.
-If you override the Micronaut Tracing version, import the matching `io.micronaut.tracing:micronaut-tracing-bom` as well so exporters use the OpenTelemetry version expected by the tracing instrumentation.
+If you override the Micronaut Tracing version, import the matching `io.micronaut.tracing:micronaut-tracing-bom` as well so that exporters use the OpenTelemetry version expected by the tracing instrumentation.
 
 - OpenTelemetry Protocol exporter: `otlp`
 dependency:opentelemetry-exporter-otlp[scope="implementation", groupId="io.opentelemetry"]


### PR DESCRIPTION
## Summary
- document that OpenTelemetry dependencies must be resolved from the same dependency-management line as Micronaut Tracing OpenTelemetry modules
- call out importing the matching `micronaut-tracing-bom` when overriding Micronaut Tracing independently from the Micronaut Platform
- add exporter-specific guidance because versionless exporters rely on Micronaut dependency management

## Verification
- `./gradlew publishGuide -q`
- `./gradlew docs -q`
- `git diff --check`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/229
