### PR TITLE
Document OpenTelemetry SDK customization

### DIFF
--- a/src/main/docs/guide/opentelemetry/customization.adoc
+++ b/src/main/docs/guide/opentelemetry/customization.adoc
@@ -1,6 +1,6 @@
 You can provide a bean of type api:tracing.opentelemetry.OpenTelemetryBuilderCustomizer[] to customize the OpenTelemetry autoconfigured SDK builder before Micronaut creates the `io.opentelemetry.api.OpenTelemetry` bean.
 
-For example, a customizer can register a metric view with explicit histogram bucket boundaries:
+For example, a customizer can register a metric view with an explicit histogram aggregation:
 
 snippet::io.micronaut.tracing.opentelemetry.OpenTelemetryBuilderCustomizerExample[tags="imports,histogramViewCustomizer", project="test-suite-java"]
 

--- a/src/main/docs/guide/opentelemetry/customization.adoc
+++ b/src/main/docs/guide/opentelemetry/customization.adoc
@@ -2,23 +2,6 @@ You can provide a bean of type api:tracing.opentelemetry.OpenTelemetryBuilderCus
 
 For example, a customizer can register a metric view with explicit histogram bucket boundaries:
 
-[source,java]
-----
-@Singleton
-OpenTelemetryBuilderCustomizer histogramViewCustomizer() {
-    return builder -> builder.addMeterProviderCustomizer((meterProviderBuilder, configProperties) -> {
-        meterProviderBuilder.registerView(
-            InstrumentSelector.builder()
-                .setType(InstrumentType.HISTOGRAM)
-                .setName("http.server.request.duration")
-                .build(),
-            View.builder()
-                .setAggregation(Aggregation.explicitBucketHistogram(Arrays.asList(0.005, 0.01, 0.025, 0.05, 0.1)))
-                .build()
-        );
-        return meterProviderBuilder;
-    });
-}
-----
+snippet::io.micronaut.tracing.opentelemetry.OpenTelemetryBuilderCustomizerExample[tags="imports,histogramViewCustomizer", project="test-suite-java"]
 
 The customizer receives the same `AutoConfiguredOpenTelemetrySdkBuilder` that Micronaut uses internally, so it can also use the OpenTelemetry SDK autoconfigure extension points such as tracer provider customizers, meter provider customizers, log record processor customizers, and property suppliers.

--- a/src/main/docs/guide/opentelemetry/customization.adoc
+++ b/src/main/docs/guide/opentelemetry/customization.adoc
@@ -1,6 +1,6 @@
 You can provide a bean of type api:tracing.opentelemetry.OpenTelemetryBuilderCustomizer[] to customize the OpenTelemetry autoconfigured SDK builder before Micronaut creates the `io.opentelemetry.api.OpenTelemetry` bean.
 
-For example, a customizer can register a metric view with an explicit histogram aggregation:
+For example, a customizer can register a metric view with an explicit histogram aggregation and custom bucket boundaries:
 
 snippet::io.micronaut.tracing.opentelemetry.OpenTelemetryBuilderCustomizerExample[tags="imports,histogramViewCustomizer", project="test-suite-java"]
 

--- a/src/main/docs/guide/opentelemetry/customization.adoc
+++ b/src/main/docs/guide/opentelemetry/customization.adoc
@@ -1,4 +1,4 @@
-You can provide a bean of type api:tracing.opentelemetry.OpenTelemetryBuilderCustomizer[] to customize the OpenTelemetry autoconfigured SDK builder before Micronaut creates the api:opentelemetry.OpenTelemetry[] bean.
+You can provide a bean of type api:tracing.opentelemetry.OpenTelemetryBuilderCustomizer[] to customize the OpenTelemetry autoconfigured SDK builder before Micronaut creates the `io.opentelemetry.api.OpenTelemetry` bean.
 
 For example, a customizer can register a metric view with explicit histogram bucket boundaries:
 

--- a/src/main/docs/guide/opentelemetry/customization.adoc
+++ b/src/main/docs/guide/opentelemetry/customization.adoc
@@ -1,0 +1,24 @@
+You can provide a bean of type api:tracing.opentelemetry.OpenTelemetryBuilderCustomizer[] to customize the OpenTelemetry autoconfigured SDK builder before Micronaut creates the api:opentelemetry.OpenTelemetry[] bean.
+
+For example, a customizer can register a metric view with explicit histogram bucket boundaries:
+
+[source,java]
+----
+@Singleton
+OpenTelemetryBuilderCustomizer histogramViewCustomizer() {
+    return builder -> builder.addMeterProviderCustomizer((meterProviderBuilder, configProperties) -> {
+        meterProviderBuilder.registerView(
+            InstrumentSelector.builder()
+                .setType(InstrumentType.HISTOGRAM)
+                .setName("http.server.request.duration")
+                .build(),
+            View.builder()
+                .setAggregation(Aggregation.explicitBucketHistogram(Arrays.asList(0.005, 0.01, 0.025, 0.05, 0.1)))
+                .build()
+        );
+        return meterProviderBuilder;
+    });
+}
+----
+
+The customizer receives the same `AutoConfiguredOpenTelemetrySdkBuilder` that Micronaut uses internally, so it can also use the OpenTelemetry SDK autoconfigure extension points such as tracer provider customizers, meter provider customizers, log record processor customizers, and property suppliers.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -9,6 +9,7 @@ opentelemetry:
   annotations: OpenTelemetry Annotations
   exporters: OpenTelemetry Exporters
   logback: Logback
+  customization: OpenTelemetry SDK Customization
   propagators: OpenTelemetry Propagators
   idgenerator: ID Generator
   http: HTTP Server and Client

--- a/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
+++ b/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
@@ -7,11 +7,15 @@ import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.View;
 import jakarta.inject.Singleton;
+
+import java.util.List;
 //end::imports[]
 
 //tag::histogramViewCustomizer[]
 @Factory
 class OpenTelemetryBuilderCustomizerExample {
+
+    private static final List<Double> HISTOGRAM_BOUNDARIES = List.of(1.0d, 5.0d, 10.0d);
 
     @Singleton
     OpenTelemetryBuilderCustomizer histogramViewCustomizer() {
@@ -22,7 +26,7 @@ class OpenTelemetryBuilderCustomizerExample {
                     .setName("http.server.request.duration")
                     .build(),
                 View.builder()
-                    .setAggregation(Aggregation.explicitBucketHistogram())
+                    .setAggregation(Aggregation.explicitBucketHistogram(HISTOGRAM_BOUNDARIES))
                     .build()
             );
             return meterProviderBuilder;

--- a/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
+++ b/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
@@ -1,6 +1,7 @@
 package io.micronaut.tracing.opentelemetry;
 
 //tag::imports[]
+import io.micronaut.context.annotation.Factory;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -10,9 +11,10 @@ import jakarta.inject.Singleton;
 import java.util.Arrays;
 //end::imports[]
 
+//tag::histogramViewCustomizer[]
+@Factory
 class OpenTelemetryBuilderCustomizerExample {
 
-    //tag::histogramViewCustomizer[]
     @Singleton
     OpenTelemetryBuilderCustomizer histogramViewCustomizer() {
         return builder -> builder.addMeterProviderCustomizer((meterProviderBuilder, configProperties) -> {
@@ -28,5 +30,5 @@ class OpenTelemetryBuilderCustomizerExample {
             return meterProviderBuilder;
         });
     }
-    //end::histogramViewCustomizer[]
 }
+//end::histogramViewCustomizer[]

--- a/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
+++ b/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
@@ -1,0 +1,32 @@
+package io.micronaut.tracing.opentelemetry;
+
+//tag::imports[]
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.View;
+import jakarta.inject.Singleton;
+
+import java.util.Arrays;
+//end::imports[]
+
+class OpenTelemetryBuilderCustomizerExample {
+
+    //tag::histogramViewCustomizer[]
+    @Singleton
+    OpenTelemetryBuilderCustomizer histogramViewCustomizer() {
+        return builder -> builder.addMeterProviderCustomizer((meterProviderBuilder, configProperties) -> {
+            meterProviderBuilder.registerView(
+                InstrumentSelector.builder()
+                    .setType(InstrumentType.HISTOGRAM)
+                    .setName("http.server.request.duration")
+                    .build(),
+                View.builder()
+                    .setAggregation(Aggregation.explicitBucketHistogram(Arrays.asList(0.005, 0.01, 0.025, 0.05, 0.1)))
+                    .build()
+            );
+            return meterProviderBuilder;
+        });
+    }
+    //end::histogramViewCustomizer[]
+}

--- a/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
+++ b/test-suite-java/src/test/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerExample.java
@@ -7,8 +7,6 @@ import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.View;
 import jakarta.inject.Singleton;
-
-import java.util.Arrays;
 //end::imports[]
 
 //tag::histogramViewCustomizer[]
@@ -24,7 +22,7 @@ class OpenTelemetryBuilderCustomizerExample {
                     .setName("http.server.request.duration")
                     .build(),
                 View.builder()
-                    .setAggregation(Aggregation.explicitBucketHistogram(Arrays.asList(0.005, 0.01, 0.025, 0.05, 0.1)))
+                    .setAggregation(Aggregation.explicitBucketHistogram())
                     .build()
             );
             return meterProviderBuilder;

--- a/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizer.java
+++ b/tracing-opentelemetry/src/main/java/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizer.java
@@ -20,7 +20,10 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 /**
  * Allows external configuration of the AutoConfiguredOpenTelemetrySdkBuilder
  * created in DefaultOpenTelemetryFactory.
+ *
+ * @since 7.1.0
  */
+@FunctionalInterface
 public interface OpenTelemetryBuilderCustomizer {
 
     /**

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentelemetry/OpenTelemetryBuilderCustomizerSpec.groovy
@@ -1,0 +1,71 @@
+package io.micronaut.tracing.opentelemetry
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.sdk.metrics.Aggregation
+import io.opentelemetry.sdk.metrics.InstrumentSelector
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.View
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+@Property(name = "spec.name", value = "OpenTelemetryBuilderCustomizerSpec")
+class OpenTelemetryBuilderCustomizerSpec extends Specification {
+
+    private static final String HISTOGRAM_NAME = "custom.bucket.histogram"
+    private static final List<Double> HISTOGRAM_BOUNDARIES = [1.0d, 5.0d, 10.0d]
+
+    @Inject
+    OpenTelemetry openTelemetry
+
+    @Inject
+    InMemoryMetricReader metricReader
+
+    void "builder customizer can register histogram views"() {
+        given:
+        def histogram = openTelemetry.getMeter("test").histogramBuilder(HISTOGRAM_NAME).build()
+
+        when:
+        histogram.record(0.5d)
+        histogram.record(6.0d)
+        def metric = metricReader.collectAllMetrics().find { it.name == HISTOGRAM_NAME }
+
+        then:
+        metric != null
+        metric.histogramData.points.first().boundaries == HISTOGRAM_BOUNDARIES
+        metric.histogramData.points.first().counts == [1L, 0L, 1L, 0L]
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = "OpenTelemetryBuilderCustomizerSpec")
+    static class CustomizerFactory {
+
+        @Singleton
+        InMemoryMetricReader metricReader() {
+            InMemoryMetricReader.create()
+        }
+
+        @Singleton
+        OpenTelemetryBuilderCustomizer histogramViewCustomizer(InMemoryMetricReader metricReader) {
+            { builder -> builder.addMeterProviderCustomizer({ meterProviderBuilder, configProperties ->
+                meterProviderBuilder.registerMetricReader(metricReader)
+                meterProviderBuilder.registerView(
+                    InstrumentSelector.builder()
+                        .setType(InstrumentType.HISTOGRAM)
+                        .setName(HISTOGRAM_NAME)
+                        .build(),
+                    View.builder()
+                        .setAggregation(Aggregation.explicitBucketHistogram(HISTOGRAM_BOUNDARIES))
+                        .build()
+                )
+                meterProviderBuilder
+            }) } as OpenTelemetryBuilderCustomizer
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- document `OpenTelemetryBuilderCustomizer` as the supported hook for OpenTelemetry SDK autoconfigure customization
- add a focused regression spec proving meter provider customizers can register histogram views with custom bucket boundaries
- mark `OpenTelemetryBuilderCustomizer` as a functional interface and document its introduction version

## Verification

- `./gradlew :micronaut-tracing-opentelemetry:test --tests 'io.micronaut.tracing.opentelemetry.OpenTelemetryBuilderCustomizerSpec'`
- `./gradlew :micronaut-tracing-opentelemetry:check -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew docs`
- `./gradlew publishGuide`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/381
