### PR TITLE
Allow NewSpan on classes and interfaces

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -6,7 +6,7 @@ Micronaut features integration with both Zipkin and Jaeger (via the Open Tracing
 
 == Tracing Annotations
 
-The pkg:tracing.annotation[] package contains annotations that can be declared on methods to create new spans or continue existing spans.
+The pkg:tracing.annotation[] package contains annotations for creating new spans, continuing existing spans, and adding span tags.
 You can also declare ann:tracing.annotation.NewSpan[] on a class or interface to create a new span for each method invocation.
 
 The available annotations are:

--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -7,10 +7,11 @@ Micronaut features integration with both Zipkin and Jaeger (via the Open Tracing
 == Tracing Annotations
 
 The pkg:tracing.annotation[] package contains annotations that can be declared on methods to create new spans or continue existing spans.
+You can also declare ann:tracing.annotation.NewSpan[] on a class or interface to create a new span for each method invocation.
 
 The available annotations are:
 
-* The ann:tracing.annotation.NewSpan[] annotation creates a new span, wrapping the method call or reactive type.
+* The ann:tracing.annotation.NewSpan[] annotation creates a new span, wrapping the method call or reactive type. It can be declared on a method, class, or interface. Method-level annotations take precedence over class-level or interface-level annotations.
 * The ann:tracing.annotation.ContinueSpan[] annotation continues an existing span, wrapping the method call or reactive type.
 * The ann:tracing.annotation.SpanTag[] annotation can be used on method arguments to include the value of the argument within a Span's tags. When you use `@SpanTag` on an argument, you must either annotate the method with `@NewSpan` or `@ContinueSpan`.
 

--- a/tracing-annotation/src/main/java/io/micronaut/tracing/annotation/NewSpan.java
+++ b/tracing-annotation/src/main/java/io/micronaut/tracing/annotation/NewSpan.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -36,7 +37,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Retention(RUNTIME)
 @Inherited
-@Target({METHOD, ANNOTATION_TYPE})
+@Target({METHOD, TYPE, ANNOTATION_TYPE})
 @InterceptorBinding(kind = InterceptorKind.AROUND)
 public @interface NewSpan {
 

--- a/tracing-brave/src/test/groovy/io/micronaut/tracing/brave/TraceInterceptorSpec.groovy
+++ b/tracing-brave/src/test/groovy/io/micronaut/tracing/brave/TraceInterceptorSpec.groovy
@@ -91,10 +91,11 @@ class TraceInterceptorSpec extends Specification {
         interfaceLevel == 'interface-level'
         interfaceLevelOverride == 'interface-level-override'
         reporter.spans.size() == 4
-        reporter.spans.collect { it.name() }.contains('classlevelnewspanservice.classlevel')
-        reporter.spans.collect { it.name() }.contains('class-level-override')
-        reporter.spans.collect { it.name() }.contains('interfacelevelnewspanserviceimpl.interfacelevel')
-        reporter.spans.collect { it.name() }.contains('interface-level-override')
+        def spanNames = reporter.spans.collect { it.name() }
+        spanNames.contains('classlevelnewspanservice.classlevel')
+        spanNames.contains('class-level-override')
+        spanNames.contains('interfacelevelnewspanserviceimpl.interfacelevel')
+        spanNames.contains('interface-level-override')
     }
 
     private void buildContext() {

--- a/tracing-brave/src/test/groovy/io/micronaut/tracing/brave/TraceInterceptorSpec.groovy
+++ b/tracing-brave/src/test/groovy/io/micronaut/tracing/brave/TraceInterceptorSpec.groovy
@@ -24,6 +24,8 @@ class TraceInterceptorSpec extends Specification {
     @AutoCleanup
     private ApplicationContext applicationContext
     private TracedService tracedService
+    private ClassLevelNewSpanService classLevelNewSpanService
+    private InterfaceLevelNewSpanService interfaceLevelNewSpanService
     private TestReporter reporter
 
     void 'test trace interceptor'() {
@@ -75,6 +77,26 @@ class TraceInterceptorSpec extends Specification {
         reporter.spans[0].tags()['method'] == 'noArgNewSpan'
     }
 
+    void 'test NewSpan declared on classes and interfaces'() {
+        when:
+        buildContext()
+        def classLevel = classLevelNewSpanService.classLevel()
+        def classLevelOverride = classLevelNewSpanService.classLevelOverride()
+        def interfaceLevel = interfaceLevelNewSpanService.interfaceLevel()
+        def interfaceLevelOverride = interfaceLevelNewSpanService.interfaceLevelOverride()
+
+        then:
+        classLevel == 'class-level'
+        classLevelOverride == 'class-level-override'
+        interfaceLevel == 'interface-level'
+        interfaceLevelOverride == 'interface-level-override'
+        reporter.spans.size() == 4
+        reporter.spans.collect { it.name() }.contains('classlevelnewspanservice.classlevel')
+        reporter.spans.collect { it.name() }.contains('class-level-override')
+        reporter.spans.collect { it.name() }.contains('interfacelevelnewspanserviceimpl.interfacelevel')
+        reporter.spans.collect { it.name() }.contains('interface-level-override')
+    }
+
     private void buildContext() {
         applicationContext = ApplicationContext
                 .builder('tracing.zipkin.enabled': true,
@@ -82,6 +104,8 @@ class TraceInterceptorSpec extends Specification {
                 .singletons(new TestReporter())
                 .start()
         tracedService = applicationContext.getBean(TracedService)
+        classLevelNewSpanService = applicationContext.getBean(ClassLevelNewSpanService)
+        interfaceLevelNewSpanService = applicationContext.getBean(InterfaceLevelNewSpanService)
         reporter = applicationContext.getBean(TestReporter)
     }
 
@@ -119,6 +143,43 @@ class TraceInterceptorSpec extends Specification {
                 spanCustomizer.tag('foo', 'bar')
                 return v
             })
+        }
+    }
+
+    @Singleton
+    @NewSpan
+    static class ClassLevelNewSpanService {
+
+        String classLevel() {
+            return 'class-level'
+        }
+
+        @NewSpan('class-level-override')
+        String classLevelOverride() {
+            return 'class-level-override'
+        }
+    }
+
+    @NewSpan
+    static interface InterfaceLevelNewSpanService {
+
+        String interfaceLevel()
+
+        String interfaceLevelOverride()
+    }
+
+    @Singleton
+    static class InterfaceLevelNewSpanServiceImpl implements InterfaceLevelNewSpanService {
+
+        @Override
+        String interfaceLevel() {
+            return 'interface-level'
+        }
+
+        @Override
+        @NewSpan('interface-level-override')
+        String interfaceLevelOverride() {
+            return 'interface-level-override'
         }
     }
 }

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentracing/instrument/util/AnnotationMappingSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentracing/instrument/util/AnnotationMappingSpec.groovy
@@ -124,11 +124,12 @@ class AnnotationMappingSpec extends Specification {
         interfaceLevel == 'interface-level'
         interfaceLevelOverride == 'interface-level-override'
         conditions.eventually {
-            testExporter.finishedSpanItems.size() == 4
-            testExporter.finishedSpanItems.name.any(x -> x.contains('classLevel'))
-            testExporter.finishedSpanItems.name.any(x -> x.contains('classLevelOverride#class-level-override'))
-            testExporter.finishedSpanItems.name.any(x -> x.contains('interfaceLevel'))
-            testExporter.finishedSpanItems.name.any(x -> x.contains('interfaceLevelOverride#interface-level-override'))
+            def spanNames = testExporter.finishedSpanItems*.name
+            spanNames.size() == 4
+            spanNames.contains('ClassLevelNewSpanService.classLevel')
+            spanNames.contains('ClassLevelNewSpanService.classLevelOverride#class-level-override')
+            spanNames.contains('InterfaceLevelNewSpanServiceImpl.interfaceLevel')
+            spanNames.contains('InterfaceLevelNewSpanServiceImpl.interfaceLevelOverride#interface-level-override')
         }
 
         cleanup:

--- a/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentracing/instrument/util/AnnotationMappingSpec.groovy
+++ b/tracing-opentelemetry/src/test/groovy/io/micronaut/tracing/opentracing/instrument/util/AnnotationMappingSpec.groovy
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.data.SpanData
 import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.util.function.Tuple2
@@ -100,6 +101,34 @@ class AnnotationMappingSpec extends Specification {
             testExporter.finishedSpanItems.size() == 1
             testExporter.finishedSpanItems.get(0).name == "WarehouseClient.order"
             testExporter.finishedSpanItems.get(0).attributes.get(AttributeKey.stringKey("warehouse.order")) == "{testOrderKey=testOrderValue}"
+        }
+
+        cleanup:
+        testExporter.reset()
+    }
+
+    void 'new span can be declared on classes and interfaces'() {
+        def testExporter = embeddedServer.applicationContext.getBean(InMemorySpanExporter)
+        def classLevelNewSpanService = embeddedServer.applicationContext.getBean(ClassLevelNewSpanService)
+        def interfaceLevelNewSpanService = embeddedServer.applicationContext.getBean(InterfaceLevelNewSpanService)
+
+        when:
+        def classLevel = classLevelNewSpanService.classLevel()
+        def classLevelOverride = classLevelNewSpanService.classLevelOverride()
+        def interfaceLevel = interfaceLevelNewSpanService.interfaceLevel()
+        def interfaceLevelOverride = interfaceLevelNewSpanService.interfaceLevelOverride()
+
+        then:
+        classLevel == 'class-level'
+        classLevelOverride == 'class-level-override'
+        interfaceLevel == 'interface-level'
+        interfaceLevelOverride == 'interface-level-override'
+        conditions.eventually {
+            testExporter.finishedSpanItems.size() == 4
+            testExporter.finishedSpanItems.name.any(x -> x.contains('classLevel'))
+            testExporter.finishedSpanItems.name.any(x -> x.contains('classLevelOverride#class-level-override'))
+            testExporter.finishedSpanItems.name.any(x -> x.contains('interfaceLevel'))
+            testExporter.finishedSpanItems.name.any(x -> x.contains('interfaceLevelOverride#interface-level-override'))
         }
 
         cleanup:
@@ -189,5 +218,45 @@ class AnnotationMappingSpec extends Specification {
         @NewSpan
         void order(@SpanTag("warehouse.order") Map<String, ?> json);
 
+    }
+
+    @Requires(property = "spec.name", value = "AnnotationMappingSpec")
+    @Singleton
+    @NewSpan
+    static class ClassLevelNewSpanService {
+
+        String classLevel() {
+            return 'class-level'
+        }
+
+        @NewSpan("class-level-override")
+        String classLevelOverride() {
+            return 'class-level-override'
+        }
+    }
+
+    @Requires(property = "spec.name", value = "AnnotationMappingSpec")
+    @NewSpan
+    static interface InterfaceLevelNewSpanService {
+
+        String interfaceLevel()
+
+        String interfaceLevelOverride()
+    }
+
+    @Requires(property = "spec.name", value = "AnnotationMappingSpec")
+    @Singleton
+    static class InterfaceLevelNewSpanServiceImpl implements InterfaceLevelNewSpanService {
+
+        @Override
+        String interfaceLevel() {
+            return 'interface-level'
+        }
+
+        @Override
+        @NewSpan("interface-level-override")
+        String interfaceLevelOverride() {
+            return 'interface-level-override'
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Allow `@NewSpan` to be declared on classes and interfaces.
- Add OpenTelemetry and Brave/OpenTracing regression coverage for type-level spans and method-level overrides.
- Update tracing annotation documentation for type-level `@NewSpan` usage.

## Verification
- `./gradlew :micronaut-tracing-opentelemetry:test --tests 'io.micronaut.tracing.opentracing.instrument.util.AnnotationMappingSpec'`
- `./gradlew :micronaut-tracing-brave:test --tests 'io.micronaut.tracing.brave.TraceInterceptorSpec'`
- `./gradlew :micronaut-tracing-annotation:check :micronaut-tracing-opentelemetry:test --tests 'io.micronaut.tracing.opentracing.instrument.util.AnnotationMappingSpec' :micronaut-tracing-brave:test --tests 'io.micronaut.tracing.brave.TraceInterceptorSpec' spotlessCheck -x japiCmp -x checkVersionCatalogCompatibility`

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/365
