### PR TITLE
Remove OkHttp sender from Zipkin exporter dependencies

### DIFF
--- a/tracing-opentelemetry-zipkin-exporter/build.gradle
+++ b/tracing-opentelemetry-zipkin-exporter/build.gradle
@@ -6,7 +6,9 @@ plugins {
 dependencies {
     api projects.micronautTracingOpentelemetry
     api projects.micronautTracingZipkinHttpClient
-    implementation libs.opentelemetry.exporter.zipkin
+    implementation(libs.opentelemetry.exporter.zipkin) {
+        exclude group: 'io.zipkin.reporter2', module: 'zipkin-sender-okhttp3'
+    }
     testImplementation mnReactor.micronaut.reactor
     testRuntimeOnly mnSerde.micronaut.serde.jackson
     testImplementation(projects.micronautTracingOpentelemetryHttp)

--- a/tracing-opentelemetry-zipkin-exporter/src/test/groovy/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactorySpec.groovy
+++ b/tracing-opentelemetry-zipkin-exporter/src/test/groovy/io/micronaut/tracing/opentelemetry/exporter/zipkin/OtelHttpClientSenderFactorySpec.groovy
@@ -31,4 +31,12 @@ class OtelHttpClientSenderFactorySpec extends Specification {
         sender instanceof HttpClientSender
         spanProcessor instanceof BatchSpanProcessor
     }
+
+    void "okhttp is not a transitive dependency"() {
+        when:
+        Class.forName('okhttp3.OkHttpClient')
+
+        then:
+        thrown(ClassNotFoundException)
+    }
 }


### PR DESCRIPTION
## Summary
- Exclude the Zipkin OkHttp sender from the OpenTelemetry Zipkin exporter dependency.
- Keep using the Micronaut Zipkin HTTP client sender for OpenTelemetry Zipkin export.
- Add regression coverage that OkHttp is not present on the exporter test runtime classpath.

## Verification
- ./gradlew :micronaut-tracing-opentelemetry-zipkin-exporter:test --tests '*OtelHttpClientSenderFactorySpec'
- ./gradlew :micronaut-tracing-opentelemetry-zipkin-exporter:check
- ./gradlew :micronaut-tracing-opentelemetry-zipkin-exporter:dependencyInsight --configuration runtimeClasspath --dependency zipkin-sender-okhttp3 :micronaut-tracing-zipkin-http-client:dependencyInsight --configuration runtimeClasspath --dependency okhttp :micronaut-tracing-brave:dependencyInsight --configuration runtimeClasspath --dependency okhttp

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/203
