### PR TITLE
Add Micrometer Tracing bridge modules

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ micronaut-platform = "5.0.0-RC1"
 micronaut-docs = '3.0.0'
 
 managed-brave-instrumentation = '6.3.1'
+managed-micrometer-tracing = '1.5.4'
 managed-opentelemetry = '1.61.0'
 managed-opentelemetry-alpha = '1.61.0-alpha'
 managed-opentelemetry-instrumentation = '2.27.0'
@@ -82,6 +83,10 @@ zipkin = { module = 'io.zipkin.zipkin2:zipkin', version.ref = 'managed-zipkin' }
 zipkin-reporter = { module = 'io.zipkin.reporter2:zipkin-reporter' }
 zipkin-reporter-brave = { module = 'io.zipkin.reporter2:zipkin-reporter-brave' }
 
+micrometer-tracing = { module = 'io.micrometer:micrometer-tracing' }
+micrometer-tracing-bridge-brave = { module = 'io.micrometer:micrometer-tracing-bridge-brave' }
+micrometer-tracing-bridge-otel = { module = 'io.micrometer:micrometer-tracing-bridge-otel' }
+
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api' }
 opentelemetry-api-events = { module = 'io.opentelemetry:opentelemetry-api-events', version.ref = 'managed-opentelemetry-api-events' }
 opentelemetry-api-incubator = { module = 'io.opentelemetry:opentelemetry-api-incubator' }
@@ -110,6 +115,7 @@ boms-opentelemetry-alpha = { module = 'io.opentelemetry:opentelemetry-bom-alpha'
 boms-opentelemetry-instrumentation = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom', version.ref = 'managed-opentelemetry-instrumentation' }
 boms-opentelemetry-instrumentation-alpha = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha', version.ref = 'managed-opentelemetry-instrumentation-alpha' }
 boms-brave = { module = 'io.zipkin.brave:brave-bom', version.ref = 'managed-brave-instrumentation' }
+boms-micrometer-tracing = { module = 'io.micrometer:micrometer-tracing-bom', version.ref = 'managed-micrometer-tracing' }
 boms-zipkin-reporter = { module = 'io.zipkin.reporter2:zipkin-reporter-bom', version.ref = 'managed-zipkin-reporter' }
 #plugins
 micronaut-gradle-plugin = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref="micronaut-gradle-plugin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,12 @@ include 'tracing-bom'
 include 'tracing-core'
 include 'tracing-zipkin-http-client'
 
+// Micrometer Tracing
+
+include 'tracing-micrometer'
+include 'tracing-micrometer-brave'
+include 'tracing-micrometer-opentelemetry'
+
 // OpenTelemetry
 
 include 'tracing-opentelemetry'

--- a/src/main/docs/guide/micrometer.adoc
+++ b/src/main/docs/guide/micrometer.adoc
@@ -1,0 +1,34 @@
+https://micrometer.io/docs/tracing[Micrometer Tracing] provides a facade over tracer implementations.
+Micronaut Tracing can expose Micrometer Tracing beans backed by the existing OpenTelemetry or Brave integrations.
+
+When `micronaut-micrometer-observation` is on the classpath, its observation support automatically creates tracing observation handlers from the Micrometer `Tracer` and `Propagator` beans.
+
+== Configuration
+
+Micrometer Tracing bridge beans are enabled by default when a bridge module and its backing tracer are available.
+You can disable only the Micrometer bridge beans with:
+
+[configuration]
+----
+tracing:
+  micrometer:
+    enabled: false
+----
+
+You can also configure baggage fields shared by the Micrometer bridge implementations:
+
+[configuration]
+----
+tracing:
+  micrometer:
+    baggage:
+      remote-fields:
+        - x-request-id
+        - tenant
+      correlation-fields:
+        - tenant
+----
+
+include::{includedir}configurationProperties/io.micronaut.tracing.micrometer.MicrometerTracingConfigurationProperties.adoc[]
+
+include::{includedir}configurationProperties/io.micronaut.tracing.micrometer.MicrometerTracingConfigurationProperties$Baggage.adoc[]

--- a/src/main/docs/guide/micrometer/brave.adoc
+++ b/src/main/docs/guide/micrometer/brave.adoc
@@ -1,0 +1,17 @@
+To expose Micrometer Tracing beans backed by Brave, add the following dependency:
+
+dependency:micronaut-tracing-micrometer-brave[scope="implementation", groupId="io.micronaut.tracing"]
+
+You also need Brave tracing enabled.
+For example, add the Brave HTTP integration and enable Zipkin tracing:
+
+dependency:micronaut-tracing-brave-http[scope="implementation", groupId="io.micronaut.tracing"]
+
+[configuration]
+----
+tracing:
+  zipkin:
+    enabled: true
+----
+
+The bridge creates Micrometer `Tracer`, `CurrentTraceContext`, `BaggageManager`, and `Propagator` beans from the existing Brave `Tracing` bean.

--- a/src/main/docs/guide/micrometer/openTelemetryBridge.adoc
+++ b/src/main/docs/guide/micrometer/openTelemetryBridge.adoc
@@ -1,0 +1,10 @@
+To expose Micrometer Tracing beans backed by OpenTelemetry, add the following dependency:
+
+dependency:micronaut-tracing-micrometer-opentelemetry[scope="implementation", groupId="io.micronaut.tracing"]
+
+You also need an OpenTelemetry tracer on the classpath.
+For example, add the base OpenTelemetry integration:
+
+dependency:micronaut-tracing-opentelemetry[scope="implementation", groupId="io.micronaut.tracing"]
+
+The bridge creates Micrometer `Tracer`, `CurrentTraceContext`, `BaggageManager`, and `Propagator` beans from the existing OpenTelemetry beans.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,6 +4,10 @@ releaseHistory: Release History
 breaks: Breaking Changes
 jaeger: Tracing with Jaeger
 zipkin: Tracing with Zipkin
+micrometer:
+  title: Tracing with Micrometer Tracing
+  openTelemetryBridge: OpenTelemetry Bridge
+  brave: Brave Bridge
 opentelemetry:
   title: Tracing with OpenTelemetry
   annotations: OpenTelemetry Annotations

--- a/tracing-bom/build.gradle
+++ b/tracing-bom/build.gradle
@@ -44,11 +44,20 @@ micronautBom {
                         "io.zipkin.proto3"
                 ] as Set
         )
+        bomAuthorizedGroupIds.put(
+                "io.micrometer:micrometer-tracing-bom",
+                [
+                        "io.micrometer"
+                ] as Set
+        )
         dependencies.add("io.opentelemetry.semconv:opentelemetry-semconv:1.40.0")
         dependencies.add("io.opentelemetry:opentelemetry-bom:1.61.0")
         dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.61.0-alpha")
         dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.27.0")
         dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.27.0-alpha")
+        dependencies.add("io.micrometer:micrometer-tracing-bom:1.5.4")
+        dependencies.add("io.micrometer:micrometer-bom:1.15.4")
+        dependencies.add("io.micrometer:docs:1.5.4")
         dependencies.add("io.zipkin.brave:brave-instrumentation-benchmarks:6.1.0")
         dependencies.add("io.zipkin.reporter2:zipkin-reporter-bom:3.5.1")
     }

--- a/tracing-micrometer-brave/build.gradle
+++ b/tracing-micrometer-brave/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'io.micronaut.build.internal.tracing-module'
+}
+
+dependencies {
+    api platform(libs.boms.micrometer.tracing)
+    api projects.micronautTracingBrave
+    api projects.micronautTracingMicrometer
+    api libs.micrometer.tracing.bridge.brave
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter '8.0.0'
+    }
+}

--- a/tracing-micrometer-brave/src/main/java/io/micronaut/tracing/micrometer/brave/MicrometerBraveTracingFactory.java
+++ b/tracing-micrometer-brave/src/main/java/io/micronaut/tracing/micrometer/brave/MicrometerBraveTracingFactory.java
@@ -40,12 +40,6 @@ import jakarta.inject.Singleton;
 public class MicrometerBraveTracingFactory {
 
     /**
-     * Constructs Micrometer Brave tracing factory.
-     */
-    public MicrometerBraveTracingFactory() {
-    }
-
-    /**
      * Creates a Micrometer current trace context.
      *
      * @param currentTraceContext Brave current trace context

--- a/tracing-micrometer-brave/src/main/java/io/micronaut/tracing/micrometer/brave/MicrometerBraveTracingFactory.java
+++ b/tracing-micrometer-brave/src/main/java/io/micronaut/tracing/micrometer/brave/MicrometerBraveTracingFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.micrometer.brave;
+
+import brave.Tracing;
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BravePropagator;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.propagation.Propagator;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.tracing.micrometer.MicrometerTracingConfigurationProperties;
+import jakarta.inject.Singleton;
+
+/**
+ * Creates Micrometer Tracing bridge beans backed by Brave.
+ *
+ * @author original authors
+ * @since 8.0.0
+ */
+@Factory
+@Requires(beans = {MicrometerTracingConfigurationProperties.class, Tracing.class})
+public class MicrometerBraveTracingFactory {
+
+    /**
+     * Constructs Micrometer Brave tracing factory.
+     */
+    public MicrometerBraveTracingFactory() {
+    }
+
+    /**
+     * Creates a Micrometer current trace context.
+     *
+     * @param currentTraceContext Brave current trace context
+     * @return Micrometer current trace context
+     */
+    @Singleton
+    @Requires(missingBeans = CurrentTraceContext.class)
+    BraveCurrentTraceContext currentTraceContext(brave.propagation.CurrentTraceContext currentTraceContext) {
+        return new BraveCurrentTraceContext(currentTraceContext);
+    }
+
+    /**
+     * Creates a Micrometer baggage manager.
+     *
+     * @param configuration Micrometer tracing configuration
+     * @return Micrometer baggage manager
+     */
+    @Bean(preDestroy = "close")
+    @Singleton
+    @Primary
+    @Requires(missingBeans = BraveBaggageManager.class)
+    BraveBaggageManager baggageManager(MicrometerTracingConfigurationProperties configuration) {
+        MicrometerTracingConfigurationProperties.Baggage baggage = configuration.getBaggage();
+        return new BraveBaggageManager(baggage.getRemoteFields(), baggage.getCorrelationFields());
+    }
+
+    /**
+     * Creates a Micrometer tracer backed by Brave.
+     *
+     * @param tracing Brave tracing instance
+     * @param currentTraceContext Micrometer current trace context
+     * @param baggageManager Micrometer baggage manager
+     * @return Micrometer tracer
+     */
+    @Singleton
+    @Requires(missingBeans = io.micrometer.tracing.Tracer.class)
+    io.micrometer.tracing.Tracer micrometerTracer(Tracing tracing,
+                                                  CurrentTraceContext currentTraceContext,
+                                                  BraveBaggageManager baggageManager) {
+        return new BraveTracer(tracing.tracer(), currentTraceContext, baggageManager);
+    }
+
+    /**
+     * Creates a Micrometer propagator backed by Brave.
+     *
+     * @param tracing Brave tracing instance
+     * @return Micrometer propagator
+     */
+    @Singleton
+    @Requires(missingBeans = Propagator.class)
+    Propagator propagator(Tracing tracing) {
+        return new BravePropagator(tracing);
+    }
+}

--- a/tracing-micrometer-brave/src/main/java/io/micronaut/tracing/micrometer/brave/package-info.java
+++ b/tracing-micrometer-brave/src/main/java/io/micronaut/tracing/micrometer/brave/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Micrometer Tracing integration backed by Brave.
+ *
+ * @author original authors
+ * @since 8.0.0
+ */
+@Configuration
+@Requires(classes = {BraveTracer.class, Tracing.class})
+package io.micronaut.tracing.micrometer.brave;
+
+import brave.Tracing;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;

--- a/tracing-micrometer-brave/src/test/groovy/io/micronaut/tracing/micrometer/brave/MicrometerBraveTracingFactorySpec.groovy
+++ b/tracing-micrometer-brave/src/test/groovy/io/micronaut/tracing/micrometer/brave/MicrometerBraveTracingFactorySpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.tracing.micrometer.brave
+
+import io.micrometer.tracing.BaggageManager
+import io.micrometer.tracing.CurrentTraceContext
+import io.micrometer.tracing.Tracer
+import io.micrometer.tracing.brave.bridge.BraveBaggageManager
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext
+import io.micrometer.tracing.brave.bridge.BravePropagator
+import io.micrometer.tracing.brave.bridge.BraveTracer
+import io.micrometer.tracing.propagation.Propagator
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class MicrometerBraveTracingFactorySpec extends Specification {
+
+    void 'test micrometer tracing beans are backed by brave'() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                'micronaut.application.name': 'micrometer-brave-test',
+                'tracing.zipkin.enabled': true,
+                'tracing.micrometer.baggage.remote-fields': ['x-request-id'],
+                'tracing.micrometer.baggage.correlation-fields': ['tenant']
+        )
+
+        expect:
+        context.getBean(CurrentTraceContext) instanceof BraveCurrentTraceContext
+        context.getBean(BaggageManager) instanceof BraveBaggageManager
+        context.getBean(Tracer) instanceof BraveTracer
+        context.getBean(Propagator) instanceof BravePropagator
+        context.getBean(Tracer).baggageFields.contains('x-request-id')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test micrometer tracing beans are not created when disabled'() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                'micronaut.application.name': 'micrometer-brave-test',
+                'tracing.zipkin.enabled': true,
+                'tracing.micrometer.enabled': false
+        )
+
+        expect:
+        !context.containsBean(Tracer)
+        !context.containsBean(Propagator)
+
+        cleanup:
+        context.close()
+    }
+}

--- a/tracing-micrometer-opentelemetry/build.gradle
+++ b/tracing-micrometer-opentelemetry/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'io.micronaut.build.internal.tracing-module'
+}
+
+dependencies {
+    api platform(libs.boms.micrometer.tracing)
+    api projects.micronautTracingMicrometer
+    api projects.micronautTracingOpentelemetry
+    api libs.micrometer.tracing.bridge.otel
+
+    testImplementation libs.opentelemetry.sdk
+    testImplementation libs.opentelemetry.sdk.testing
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter '8.0.0'
+    }
+}

--- a/tracing-micrometer-opentelemetry/src/main/java/io/micronaut/tracing/micrometer/opentelemetry/MicrometerOpenTelemetryTracingFactory.java
+++ b/tracing-micrometer-opentelemetry/src/main/java/io/micronaut/tracing/micrometer/opentelemetry/MicrometerOpenTelemetryTracingFactory.java
@@ -39,12 +39,6 @@ import jakarta.inject.Singleton;
 public class MicrometerOpenTelemetryTracingFactory {
 
     /**
-     * Constructs Micrometer OpenTelemetry tracing factory.
-     */
-    public MicrometerOpenTelemetryTracingFactory() {
-    }
-
-    /**
      * Creates a Micrometer current trace context.
      *
      * @return Micrometer current trace context
@@ -85,7 +79,9 @@ public class MicrometerOpenTelemetryTracingFactory {
     io.micrometer.tracing.Tracer micrometerTracer(io.opentelemetry.api.trace.Tracer tracer,
                                                   OtelCurrentTraceContext currentTraceContext,
                                                   OtelBaggageManager baggageManager) {
-        return new OtelTracer(tracer, currentTraceContext, event -> { }, baggageManager);
+        return new OtelTracer(tracer, currentTraceContext, event -> {
+            // Micronaut does not publish Micrometer span events for this bridge.
+        }, baggageManager);
     }
 
     /**

--- a/tracing-micrometer-opentelemetry/src/main/java/io/micronaut/tracing/micrometer/opentelemetry/MicrometerOpenTelemetryTracingFactory.java
+++ b/tracing-micrometer-opentelemetry/src/main/java/io/micronaut/tracing/micrometer/opentelemetry/MicrometerOpenTelemetryTracingFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.micrometer.opentelemetry;
+
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.otel.bridge.OtelBaggageManager;
+import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
+import io.micrometer.tracing.otel.bridge.OtelPropagator;
+import io.micrometer.tracing.otel.bridge.OtelTracer;
+import io.micrometer.tracing.propagation.Propagator;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.tracing.micrometer.MicrometerTracingConfigurationProperties;
+import io.opentelemetry.api.OpenTelemetry;
+import jakarta.inject.Singleton;
+
+/**
+ * Creates Micrometer Tracing bridge beans backed by OpenTelemetry.
+ *
+ * @author original authors
+ * @since 8.0.0
+ */
+@Factory
+@Requires(beans = MicrometerTracingConfigurationProperties.class)
+public class MicrometerOpenTelemetryTracingFactory {
+
+    /**
+     * Constructs Micrometer OpenTelemetry tracing factory.
+     */
+    public MicrometerOpenTelemetryTracingFactory() {
+    }
+
+    /**
+     * Creates a Micrometer current trace context.
+     *
+     * @return Micrometer current trace context
+     */
+    @Singleton
+    @Requires(missingBeans = CurrentTraceContext.class)
+    OtelCurrentTraceContext currentTraceContext() {
+        return new OtelCurrentTraceContext();
+    }
+
+    /**
+     * Creates a Micrometer baggage manager.
+     *
+     * @param configuration Micrometer tracing configuration
+     * @param currentTraceContext Micrometer current trace context
+     * @return Micrometer baggage manager
+     */
+    @Singleton
+    @Primary
+    @Requires(missingBeans = OtelBaggageManager.class)
+    OtelBaggageManager baggageManager(MicrometerTracingConfigurationProperties configuration,
+                                      OtelCurrentTraceContext currentTraceContext) {
+        MicrometerTracingConfigurationProperties.Baggage baggage = configuration.getBaggage();
+        return new OtelBaggageManager(currentTraceContext, baggage.getRemoteFields(), baggage.getCorrelationFields());
+    }
+
+    /**
+     * Creates a Micrometer tracer backed by OpenTelemetry.
+     *
+     * @param tracer OpenTelemetry tracer
+     * @param currentTraceContext Micrometer current trace context
+     * @param baggageManager Micrometer baggage manager
+     * @return Micrometer tracer
+     */
+    @Singleton
+    @Requires(beans = io.opentelemetry.api.trace.Tracer.class)
+    @Requires(missingBeans = io.micrometer.tracing.Tracer.class)
+    io.micrometer.tracing.Tracer micrometerTracer(io.opentelemetry.api.trace.Tracer tracer,
+                                                  OtelCurrentTraceContext currentTraceContext,
+                                                  OtelBaggageManager baggageManager) {
+        return new OtelTracer(tracer, currentTraceContext, event -> { }, baggageManager);
+    }
+
+    /**
+     * Creates a Micrometer propagator backed by OpenTelemetry propagators.
+     *
+     * @param openTelemetry OpenTelemetry instance
+     * @param tracer OpenTelemetry tracer
+     * @return Micrometer propagator
+     */
+    @Singleton
+    @Requires(beans = {OpenTelemetry.class, io.opentelemetry.api.trace.Tracer.class})
+    @Requires(missingBeans = Propagator.class)
+    Propagator propagator(OpenTelemetry openTelemetry, io.opentelemetry.api.trace.Tracer tracer) {
+        return new OtelPropagator(openTelemetry.getPropagators(), tracer);
+    }
+}

--- a/tracing-micrometer-opentelemetry/src/main/java/io/micronaut/tracing/micrometer/opentelemetry/package-info.java
+++ b/tracing-micrometer-opentelemetry/src/main/java/io/micronaut/tracing/micrometer/opentelemetry/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Micrometer Tracing integration backed by OpenTelemetry.
+ *
+ * @author original authors
+ * @since 8.0.0
+ */
+@Configuration
+@Requires(classes = {OtelTracer.class, OpenTelemetry.class})
+package io.micronaut.tracing.micrometer.opentelemetry;
+
+import io.micrometer.tracing.otel.bridge.OtelTracer;
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.opentelemetry.api.OpenTelemetry;

--- a/tracing-micrometer-opentelemetry/src/test/groovy/io/micronaut/tracing/micrometer/opentelemetry/MicrometerOpenTelemetryTracingFactorySpec.groovy
+++ b/tracing-micrometer-opentelemetry/src/test/groovy/io/micronaut/tracing/micrometer/opentelemetry/MicrometerOpenTelemetryTracingFactorySpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.tracing.micrometer.opentelemetry
+
+import io.micrometer.tracing.BaggageManager
+import io.micrometer.tracing.CurrentTraceContext
+import io.micrometer.tracing.Tracer
+import io.micrometer.tracing.otel.bridge.OtelBaggageManager
+import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext
+import io.micrometer.tracing.otel.bridge.OtelPropagator
+import io.micrometer.tracing.otel.bridge.OtelTracer
+import io.micrometer.tracing.propagation.Propagator
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class MicrometerOpenTelemetryTracingFactorySpec extends Specification {
+
+    void 'test micrometer tracing beans are backed by opentelemetry'() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                'micronaut.application.name': 'micrometer-otel-test',
+                'tracing.micrometer.baggage.remote-fields': ['x-request-id'],
+                'tracing.micrometer.baggage.correlation-fields': ['tenant']
+        )
+
+        expect:
+        context.getBean(CurrentTraceContext) instanceof OtelCurrentTraceContext
+        context.getBean(BaggageManager) instanceof OtelBaggageManager
+        context.getBean(Tracer) instanceof OtelTracer
+        context.getBean(Propagator) instanceof OtelPropagator
+        context.getBean(Tracer).baggageFields.contains('x-request-id')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test micrometer tracing beans are not created when disabled'() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                'micronaut.application.name': 'micrometer-otel-test',
+                'tracing.micrometer.enabled': false
+        )
+
+        expect:
+        !context.containsBean(Tracer)
+        !context.containsBean(Propagator)
+
+        cleanup:
+        context.close()
+    }
+}

--- a/tracing-micrometer/build.gradle
+++ b/tracing-micrometer/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'io.micronaut.build.internal.tracing-module'
+}
+
+dependencies {
+    api platform(libs.boms.micrometer.tracing)
+    api mn.micronaut.context
+    api libs.micrometer.tracing
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter '8.0.0'
+    }
+}

--- a/tracing-micrometer/src/main/java/io/micronaut/tracing/micrometer/MicrometerTracingConfigurationProperties.java
+++ b/tracing-micrometer/src/main/java/io/micronaut/tracing/micrometer/MicrometerTracingConfigurationProperties.java
@@ -46,12 +46,6 @@ public class MicrometerTracingConfigurationProperties implements Toggleable {
     private boolean enabled = DEFAULT_ENABLED;
     private Baggage baggage = new Baggage();
 
-    /**
-     * Constructs Micrometer Tracing configuration properties.
-     */
-    public MicrometerTracingConfigurationProperties() {
-    }
-
     @Override
     public boolean isEnabled() {
         return enabled;
@@ -92,12 +86,6 @@ public class MicrometerTracingConfigurationProperties implements Toggleable {
 
         private List<String> remoteFields = Collections.emptyList();
         private List<String> correlationFields = Collections.emptyList();
-
-        /**
-         * Constructs baggage configuration.
-         */
-        public Baggage() {
-        }
 
         /**
          * Baggage field names propagated to remote services.

--- a/tracing-micrometer/src/main/java/io/micronaut/tracing/micrometer/MicrometerTracingConfigurationProperties.java
+++ b/tracing-micrometer/src/main/java/io/micronaut/tracing/micrometer/MicrometerTracingConfigurationProperties.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.micrometer;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.Toggleable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configuration properties for Micrometer Tracing.
+ *
+ * @author original authors
+ * @since 8.0.0
+ */
+@Requires(property = MicrometerTracingConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+@ConfigurationProperties(MicrometerTracingConfigurationProperties.PREFIX)
+public class MicrometerTracingConfigurationProperties implements Toggleable {
+
+    /**
+     * Configuration prefix for Micrometer Tracing.
+     */
+    public static final String PREFIX = "tracing.micrometer";
+
+    /**
+     * The default enabled value.
+     */
+    public static final boolean DEFAULT_ENABLED = true;
+
+    private boolean enabled = DEFAULT_ENABLED;
+    private Baggage baggage = new Baggage();
+
+    /**
+     * Constructs Micrometer Tracing configuration properties.
+     */
+    public MicrometerTracingConfigurationProperties() {
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables Micrometer Tracing bridge beans.
+     *
+     * @param enabled True if enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Baggage configuration.
+     *
+     * @return baggage configuration
+     */
+    public Baggage getBaggage() {
+        return baggage;
+    }
+
+    /**
+     * Sets baggage configuration.
+     *
+     * @param baggage baggage configuration
+     */
+    public void setBaggage(Baggage baggage) {
+        this.baggage = baggage == null ? new Baggage() : baggage;
+    }
+
+    /**
+     * Baggage configuration.
+     */
+    @ConfigurationProperties("baggage")
+    public static class Baggage {
+
+        private List<String> remoteFields = Collections.emptyList();
+        private List<String> correlationFields = Collections.emptyList();
+
+        /**
+         * Constructs baggage configuration.
+         */
+        public Baggage() {
+        }
+
+        /**
+         * Baggage field names propagated to remote services.
+         *
+         * @return baggage field names propagated to remote services
+         */
+        public List<String> getRemoteFields() {
+            return remoteFields;
+        }
+
+        /**
+         * Sets baggage field names propagated to remote services.
+         *
+         * @param remoteFields baggage field names propagated to remote services
+         */
+        public void setRemoteFields(List<String> remoteFields) {
+            this.remoteFields = remoteFields == null ? Collections.emptyList() : remoteFields;
+        }
+
+        /**
+         * Baggage field names correlated locally, for example with logging.
+         *
+         * @return baggage field names correlated locally, for example with logging
+         */
+        public List<String> getCorrelationFields() {
+            return correlationFields;
+        }
+
+        /**
+         * Sets baggage field names correlated locally, for example with logging.
+         *
+         * @param correlationFields baggage field names correlated locally, for example with logging
+         */
+        public void setCorrelationFields(List<String> correlationFields) {
+            this.correlationFields = correlationFields == null ? Collections.emptyList() : correlationFields;
+        }
+    }
+}

--- a/tracing-micrometer/src/main/java/io/micronaut/tracing/micrometer/package-info.java
+++ b/tracing-micrometer/src/main/java/io/micronaut/tracing/micrometer/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Common configuration for Micrometer Tracing integrations.
+ *
+ * @author original authors
+ * @since 8.0.0
+ */
+@Configuration
+@Requires(classes = Tracer.class)
+package io.micronaut.tracing.micrometer;
+
+import io.micrometer.tracing.Tracer;
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;

--- a/tracing-micrometer/src/test/groovy/io/micronaut/tracing/micrometer/MicrometerTracingConfigurationPropertiesSpec.groovy
+++ b/tracing-micrometer/src/test/groovy/io/micronaut/tracing/micrometer/MicrometerTracingConfigurationPropertiesSpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.tracing.micrometer
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class MicrometerTracingConfigurationPropertiesSpec extends Specification {
+
+    void 'test micrometer tracing configuration defaults'() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when:
+        MicrometerTracingConfigurationProperties configuration = context.getBean(MicrometerTracingConfigurationProperties)
+
+        then:
+        configuration.enabled
+        configuration.baggage.remoteFields.empty
+        configuration.baggage.correlationFields.empty
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test micrometer tracing baggage configuration'() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                'tracing.micrometer.baggage.remote-fields': ['x-request-id', 'tenant'],
+                'tracing.micrometer.baggage.correlation-fields': ['tenant']
+        )
+
+        when:
+        MicrometerTracingConfigurationProperties configuration = context.getBean(MicrometerTracingConfigurationProperties)
+
+        then:
+        configuration.baggage.remoteFields == ['x-request-id', 'tenant']
+        configuration.baggage.correlationFields == ['tenant']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test micrometer tracing can be disabled'() {
+        given:
+        ApplicationContext context = ApplicationContext.run('tracing.micrometer.enabled': false)
+
+        expect:
+        !context.containsBean(MicrometerTracingConfigurationProperties)
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
## Summary
- add common Micrometer Tracing configuration and baggage settings
- add Micrometer bridge modules backed by OpenTelemetry and Brave
- align OpenTelemetry/GRPC dependency management and Micrometer bridge bean replacement behavior
- document Micrometer Tracing usage and wire the new modules into the BOM

## Testing
- ./gradlew :micronaut-tracing-micrometer:test :micronaut-tracing-micrometer-opentelemetry:test :micronaut-tracing-micrometer-brave:test
- ./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility

Resolves https://github.com/micronaut-projects/micronaut-tracing/issues/6
