### PR TITLE
Replace `getStatus().getCode()` with `code()`

### DIFF
--- a/tracing-brave-http/src/main/java/io/micronaut/tracing/brave/http/BraveTracingClientFilter.java
+++ b/tracing-brave-http/src/main/java/io/micronaut/tracing/brave/http/BraveTracingClientFilter.java
@@ -177,7 +177,7 @@ public final class BraveTracingClientFilter implements HttpClientFilter {
 
             @Override
             public int statusCode() {
-                return response.getStatus().getCode();
+                return response.code();
             }
         };
     }

--- a/tracing-brave-http/src/main/java/io/micronaut/tracing/brave/http/BraveTracingServerFilter.java
+++ b/tracing-brave-http/src/main/java/io/micronaut/tracing/brave/http/BraveTracingServerFilter.java
@@ -173,7 +173,7 @@ public final class BraveTracingServerFilter implements HttpServerFilter {
 
             @Override
             public int statusCode() {
-                return response.getStatus().getCode();
+                return response.code();
             }
         };
     }

--- a/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
+++ b/tracing-opentelemetry-http/src/main/java/io/micronaut/tracing/opentelemetry/instrument/http/server/OpenTelemetryServerFilter.java
@@ -100,7 +100,7 @@ public final class OpenTelemetryServerFilter extends AbstractOpenTelemetryFilter
                 .doOnNext(mutableHttpResponse -> mutableHttpResponse.getAttribute(HttpAttributes.EXCEPTION, Exception.class)
                     .ifPresentOrElse(
                         e -> onError(request, context, mutableHttpResponse, e), () -> {
-                            if (mutableHttpResponse.status().getCode() >= 400) {
+                            if (mutableHttpResponse.code() >= 400) {
                                 onError(request, context, mutableHttpResponse, null);
                             } else {
                                 instrumenter.end(context, request, mutableHttpResponse, null);

--- a/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
+++ b/tracing-opentracing/src/main/java/io/micronaut/tracing/opentracing/instrument/http/AbstractOpenTracingFilter.java
@@ -87,11 +87,10 @@ public abstract sealed class AbstractOpenTracingFilter implements HttpFilter
     protected void setResponseTags(HttpRequest<?> request,
                                    HttpResponse<?> response,
                                    Span span) {
-        HttpStatus status = response.getStatus();
-        int code = status.getCode();
+        int code = response.code();
         if (code > HTTP_SUCCESS_CODE_UPPER_LIMIT) {
             span.setTag(TAG_HTTP_STATUS_CODE, code);
-            span.setTag(TAG_ERROR, status.getReason());
+            span.setTag(TAG_ERROR, HttpStatus.getDefaultReason(code));
         }
         request.getAttribute(ERROR, Throwable.class)
                 .ifPresent(error -> setErrorTags(span, error));

--- a/tracing-zipkin-http-client/src/main/java/io/micronaut/tracing/zipkin/http/client/HttpClientSender.java
+++ b/tracing-zipkin-http-client/src/main/java/io/micronaut/tracing/zipkin/http/client/HttpClientSender.java
@@ -118,7 +118,7 @@ public final class HttpClientSender extends Sender {
             HttpResponse<Object> response = httpClient
                     .toBlocking()
                     .exchange(POST(endpoint, Collections.emptyList()));
-            if (response.getStatus().getCode() >= MULTIPLE_CHOICES.getCode()) {
+            if (response.code() >= MULTIPLE_CHOICES.getCode()) {
                 throw new IllegalStateException("check response failed: " + response);
             }
             return CheckResult.OK;
@@ -173,7 +173,7 @@ public final class HttpClientSender extends Sender {
         @Override
         public Void execute() {
             HttpResponse<Object> response = httpClient.toBlocking().exchange(prepareRequest());
-            if (response.getStatus().getCode() >= BAD_REQUEST.getCode()) {
+            if (response.code() >= BAD_REQUEST.getCode()) {
                 throw new IllegalStateException("Response return invalid status code: " + response.getStatus());
             }
             return null;
@@ -192,7 +192,7 @@ public final class HttpClientSender extends Sender {
 
                 @Override
                 public void onNext(HttpResponse<ByteBuffer> response) {
-                    if (response.getStatus().getCode() >= BAD_REQUEST.getCode()) {
+                    if (response.code() >= BAD_REQUEST.getCode()) {
                         callback.onError(new IllegalStateException("Response return invalid status code: " + response.getStatus()));
                     } else {
                         callback.onSuccess(null);


### PR DESCRIPTION
Move from `getStatus().getCode()` to just `code()` since OpenTelemetryServerFilter will fail with exception on custom http codes