### PR TITLE
Take the checkBom OpenTelemetry suppressions from the catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,9 @@ grpc = '1.80.0'
 protobuf = '3.25.9'
 gson = '2.14.0'
 okio = '3.17.0'
-thrift = '0.23.0'
+thrift = '0.24.0'
+httpclient5 = '5.6.4'
+httpcore5 = '5.4.3'
 
 micronaut-aws = "5.0.2"
 micronaut-data = "5.1.0"
@@ -67,6 +69,9 @@ grpc-stub = { module = 'io.grpc:grpc-stub', version.ref = 'grpc' }
 gson = { module = 'com.google.code.gson:gson', version.ref = 'gson' }
 okio = { module = 'com.squareup.okio:okio', version.ref = 'okio' }
 thrift = { module = 'org.apache.thrift:libthrift', version.ref = 'thrift' }
+httpclient5 = { module = 'org.apache.httpcomponents.client5:httpclient5', version.ref = 'httpclient5' }
+httpcore5 = { module = 'org.apache.httpcomponents.core5:httpcore5', version.ref = 'httpcore5' }
+httpcore5-h2 = { module = 'org.apache.httpcomponents.core5:httpcore5-h2', version.ref = 'httpcore5' }
 jaeger = { module = 'io.jaegertracing:jaeger-thrift', version.ref = 'managed-jaeger' }
 javax-annotation = { module = 'javax.annotation:javax.annotation-api', version.ref = 'javax-annotation' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version = '' }

--- a/tracing-bom/build.gradle
+++ b/tracing-bom/build.gradle
@@ -11,6 +11,7 @@ micronautBom {
                 [
                         "io.opentelemetry",
                         "io.opentelemetry.instrumentation",
+                        "io.opentelemetry.semconv",
                         "io.opentelemetry.javaagent",
                         "io.opentelemetry.javaagent.instrumentation"
                 ] as Set
@@ -44,15 +45,14 @@ micronautBom {
                         "io.zipkin.proto3"
                 ] as Set
         )
-        dependencies.add("io.opentelemetry.semconv:opentelemetry-semconv:1.42.0")
-        // OpenTelemetry instrumentation 2.27.0 still imports the 1.61 BOMs transitively.
-        dependencies.add("io.opentelemetry:opentelemetry-bom:1.64.0")
-        dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.64.0-alpha")
-        // The catalog imports the current OpenTelemetry BOMs directly.
-        dependencies.add("io.opentelemetry:opentelemetry-bom:1.63.0")
-        dependencies.add("io.opentelemetry:opentelemetry-bom-alpha:1.63.0-alpha")
-        dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.29.0")
-        dependencies.add("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.29.0-alpha")
+        // The OpenTelemetry BOMs import each other, and the catalog imports them directly.
+        // Versions come from the catalog so a version bump does not leave stale suppressions behind.
+        dependencies.addAll([
+                "io.opentelemetry:opentelemetry-bom:${libs.versions.managed.opentelemetry.asProvider().get()}",
+                "io.opentelemetry:opentelemetry-bom-alpha:${libs.versions.managed.opentelemetry.alpha.get()}",
+                "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:${libs.versions.managed.opentelemetry.instrumentation.asProvider().get()}",
+                "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${libs.versions.managed.opentelemetry.instrumentation.alpha.get()}",
+        ])
         dependencies.add("io.zipkin.brave:brave-instrumentation-benchmarks:6.3.1")
         dependencies.add("io.zipkin.reporter2:zipkin-reporter-bom:3.5.3")
     }

--- a/tracing-jaeger/build.gradle
+++ b/tracing-jaeger/build.gradle
@@ -10,6 +10,13 @@ dependencies {
     // update to first version of libthrift not vulnerable to GHSA-7pwc-h2j2-rjgj.
     // libthrift is a transitive dependency of io.jaegertracing:jaeger-thrift.
     api(libs.thrift)
+    constraints {
+        // libthrift 0.24.0 still depends on httpclient5 5.2.1 and httpcore5 5.2, which are vulnerable to
+        // GHSA-hjcp-jmpx-g3qm, GHSA-hf6x-8p5f-cgmf and GHSA-v3jc-474w-2wm6.
+        api(libs.httpclient5)
+        api(libs.httpcore5)
+        api(libs.httpcore5.h2)
+    }
     // update to first version of gson not vulernable.
     // gson is a transitive dependency of io.jaegertracing:jaeger-core
     // https://ossindex.sonatype.org/component/pkg:maven/com.google.code.gson/gson


### PR DESCRIPTION
Fixes the failing `build (25)` and `audit (25)` checks on `8.3.x`, seen on the common-files PR #929. It blocks the other `8.3.x` PRs, including the core 5.2 bump #936.

Part of the core 5.2 rollout: micronaut-projects/micronaut-core#13110

## Cause

`8.3.x` bumped OpenTelemetry instrumentation to 2.30.0 and semconv to 1.43.0 (73ef56b4, b7df8b33). `tracing-bom/build.gradle` still pinned its `checkBom` suppressions to `opentelemetry-instrumentation-bom(-alpha):2.29.0` and `opentelemetry-semconv:1.42.0`, so `:micronaut-tracing-bom:checkBom` failed:

- `opentelemetry-instrumentation-bom:2.30.0` declares `io.opentelemetry.semconv:opentelemetry-semconv:1.43.0`, which is outside its group.
- `opentelemetry-instrumentation-bom-alpha:2.30.0-alpha` imports `opentelemetry-instrumentation-bom:2.30.0`.

`8.2.x` (still on 2.29.0) passes `checkBom` locally, so only the new minor is affected.

## Change

- The versions of the OpenTelemetry BOM suppressions now come from the version catalog (the same way micrometer-bom does it), so a future bump can't leave stale versions behind. The stale `1.63.0` entries are removed.
- `io.opentelemetry.semconv` is now an authorized group for `opentelemetry-instrumentation-bom`, as it already was for the alpha BOM. That replaces the versioned semconv suppression.

## Verification

`./gradlew :micronaut-tracing-bom:checkBom check` passes locally, with no unsilenced problems in the checkBom report.

## Vulnerability audit

`audit (25)` also failed on this PR, on the following findings. All of them come from `api(libs.thrift)` in `tracing-jaeger`, the only path:

- `org.apache.thrift:libthrift:0.23.0` (GHSA-8wv5-x4w7-5gww)
- `org.apache.httpcomponents.client5:httpclient5:5.2.1` (GHSA-hjcp-jmpx-g3qm)
- `org.apache.httpcomponents.core5:httpcore5:5.2` (GHSA-hf6x-8p5f-cgmf)
- `org.apache.httpcomponents.core5:httpcore5-h2:5.2` (GHSA-v3jc-474w-2wm6)

libthrift 0.24.0 still declares httpclient5 5.2.1 and httpcore5 5.2, so e889a872 bumps libthrift to 0.24.0 and adds `api` constraints in `tracing-jaeger` for httpclient5 5.6.4 and httpcore5/httpcore5-h2 5.4.3 (non-managed catalog entries, same approach as micronaut-projects/micronaut-elasticsearch#745). No `osv-scanner.toml` exceptions are needed.

`.github/scripts/vulnerability-audit.sh` passes locally ("No locally actionable vulnerabilities found"). The only findings left are informational ones from upstream Micronaut modules (jackson-core/lz4-java via micronaut-kafka, netty via micronaut-http-client). With the constraints applied, `./gradlew :micronaut-tracing-jaeger:check :micronaut-tracing-bom:checkBom` passes, and all 47 jaeger tests were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
